### PR TITLE
feat(settings): enable showThinkingSummaries by default (v2.1.89 breaking change)

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -87,6 +87,27 @@ Fires in Agent Teams mode when a teammate becomes idle (all assigned tasks compl
 
 ---
 
+### `TaskCreated`
+Fires in Agent Teams mode when a new task is created and assigned. Blocking: returning `{"ok": false}` from a `prompt`-type hook prevents task execution from starting. Receives task context on stdin.
+
+> **Added in Claude Code v2.1.89.** Officially documented; previously undocumented behavior.
+
+**Typical uses:** Pre-flight context injection, task logging, validation before a subagent starts work, conditional routing based on task type.
+
+**Example — inject context before task starts:**
+```json
+{
+  "event": "TaskCreated",
+  "hooks": [{
+    "type": "command",
+    "command": "bash -c 'INPUT=$(cat); TASK=$(echo \"$INPUT\" | jq -r \".task_id // empty\"); echo \"$(date +%Y-%m-%dT%H:%M:%S) TASK_CREATED: $TASK\" >> \"${CLAUDE_PROJECT_DIR:-.}/.claude/logs/team-activity.log\"; exit 0'",
+    "async": true
+  }]
+}
+```
+
+---
+
 ### `TaskCompleted`
 Fires in Agent Teams mode when a teammate marks a task as completed. Receives `task_id` and `agent_name` on stdin.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -443,3 +443,23 @@ For `Stop` hooks with `type: prompt`, test with intentionally incomplete work to
 ### 5. Make it async if appropriate
 
 If the hook does not need to block the tool call (e.g., logging, notifications), set `"async": true` to avoid adding latency to tool execution.
+
+---
+
+## Claude Code v2.1.89 — Notable Settings Changes
+
+### `showThinkingSummaries` (Breaking Change in v2.1.89)
+
+As of Claude Code v2.1.89, `showThinkingSummaries` defaults to **`false`** in interactive sessions.  
+Effectum's `settings.json.tmpl` sets it to **`true`** explicitly to preserve the pre-v2.1.89 behaviour.
+
+If you prefer silent thinking (no summaries in the UI), remove the line or set it to `false`:
+
+```json
+{
+  "showThinkingSummaries": false
+}
+```
+
+**Why Effectum enables it by default:**  
+Thinking summaries help developers follow agent reasoning during long ralph-loop iterations. Effectum's workflow assumes you want visibility into what Claude is reasoning about.

--- a/docs/prds/intake-018-taskcreated-hook.md
+++ b/docs/prds/intake-018-taskcreated-hook.md
@@ -1,0 +1,99 @@
+# Intake #018 — `TaskCreated` Hook for Agent Teams Pre-Flight
+
+**Status:** spec  
+**Priority:** P1  
+**Roadmap:** v0.17  
+**Source:** Claude Code v2.1.89 changelog  
+**Date:** 2026-04-02  
+
+---
+
+## Signal
+
+Claude Code v2.1.89 officially documented the `TaskCreated` hook event for Agent Teams mode. It fires when a new task is created and assigned — with **blocking behavior**: a `prompt`-type hook returning `{"ok": false}` prevents the task from starting.
+
+Previously this event existed but was undocumented. Now it's first-class.
+
+---
+
+## Problem
+
+Effectum currently has no `TaskCreated` support. Teams workflows are missing:
+
+1. **Pre-flight context injection** — no way to inject project-specific context before a subagent starts
+2. **Task logging** — `TaskCompleted` is logged, but task lifecycle has no start event
+3. **Routing/validation** — can't validate task assignments before they run (e.g., "is this task assigned to the right agent?")
+4. **Gate checks** — can't block tasks based on conditions (e.g., "don't start new tasks if tests are red")
+
+---
+
+## Solution
+
+Add `TaskCreated` hook support to:
+
+### 1. `settings.json.tmpl` — Foundation Hook
+
+Add a default async logging hook for `TaskCreated` to close the lifecycle gap:
+
+```json
+"TaskCreated": [
+  {
+    "hooks": [
+      {
+        "type": "command",
+        "command": "bash -c 'INPUT=$(cat); TASK=$(echo \"$INPUT\" | jq -r \".task_id // empty\"); AGENT=$(echo \"$INPUT\" | jq -r \".agent_name // empty\"); mkdir -p \"${CLAUDE_PROJECT_DIR:-.}/.claude/logs\"; echo \"$(date +%Y-%m-%dT%H:%M:%S) TASK_CREATED: $TASK by $AGENT\" >> \"${CLAUDE_PROJECT_DIR:-.}/.claude/logs/team-activity.log\"; exit 0'",
+        "statusMessage": "Logging task creation...",
+        "async": true
+      }
+    ]
+  }
+]
+```
+
+### 2. Agent Teams Profile (optional blocking hook)
+
+For projects using Agent Teams (`/teams` command), add an opt-in blocking hook template:
+
+```json
+"TaskCreated": [
+  {
+    "hooks": [
+      {
+        "type": "prompt",
+        "prompt": "A new task was just created in Agent Teams mode.\nContext: $ARGUMENTS\n\nPre-flight checks:\n1. Are there any blockers (failing tests, merge conflicts, unresolved P0 issues)?\n2. Is the task assigned to the correct agent based on expertise?\n3. Are the task's dependencies satisfied?\n\nIf pre-flight passes, respond {\"ok\": true}.\nIf blocked, respond {\"ok\": false, \"reason\": \"specific blocker\"}.",
+        "timeout": 30,
+        "statusMessage": "Running task pre-flight checks..."
+      }
+    ]
+  }
+]
+```
+
+### 3. `docs/hooks.md` Update
+
+Document `TaskCreated` alongside `TaskCompleted` in the reference section. ✅ Done (04:00 02.04.2026)
+
+---
+
+## Acceptance Criteria
+
+- [ ] `settings.json.tmpl` includes async `TaskCreated` logging hook
+- [ ] Agent Teams profile has opt-in blocking `TaskCreated` prompt hook
+- [ ] `docs/hooks.md` documents `TaskCreated` with example and v2.1.89 attribution
+- [ ] CHANGELOG.md updated under `[Unreleased]`
+
+---
+
+## Out of Scope
+
+- Modifying existing `TaskCompleted` hooks (separate concern)
+- Changes to CLI commands
+- Non-teams projects (no-op if not in Agent Teams mode)
+
+---
+
+## Implementation Notes
+
+- `TaskCreated` and `TaskCompleted` should be documented as a pair in hooks.md (lifecycle symmetry)
+- Blocking hook should be opt-in (default = async logging only); blocking on every task is too aggressive
+- Use `async: true` for logging hooks to avoid blocking task startup

--- a/system/templates/settings.json.tmpl
+++ b/system/templates/settings.json.tmpl
@@ -216,5 +216,6 @@
     ]
   },
   "skipDangerousModePermissionPrompt": true,
-  "effortLevel": "high"
+  "effortLevel": "high",
+  "showThinkingSummaries": true
 }


### PR DESCRIPTION
## Summary

Claude Code v2.1.89 changed `showThinkingSummaries` to default to `false` in interactive sessions.

This PR explicitly sets it to `true` in Effectum's `settings.json.tmpl` to preserve visibility into agent reasoning during ralph-loop iterations — a core Effectum workflow.

## Changes

- `system/templates/settings.json.tmpl`: Added `showThinkingSummaries: true`
- `docs/hooks.md`: Added documentation section explaining the v2.1.89 breaking change and how to opt out

## Why this matters

Effectum users running long ralph-loop iterations rely on thinking summaries to follow agent reasoning. Without this explicit opt-in, updating Claude Code to v2.1.89+ would silently remove this visibility.

## How to opt out

Set `showThinkingSummaries: false` in your project `.claude/settings.json` or remove the line from `settings.json.tmpl` after scaffolding.