### PR TITLE
docs(intake): #022 defer-permission spec + #024 powerup onboarding + Haiku3 deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,34 +7,104 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_PRs pending: #6 (loop-worker preset), #9 (frontmatter schema), #10 (headless CI), #11 (hooks #017+#018), #12 (absolute file_path). Target: v0.19.0_
+
+---
+
+## [0.18.3] - 2026-03-30
+
+### Fixed
+
+- **Internal Reference Cleanup** — All internal command cross-references updated to new `effect:`/`effectum:` namespace names. No deprecated names remain in non-alias files.
+
+## [0.18.2] - 2026-03-30
+
+### Fixed
+
+- **Deprecated Aliases — Full Content** — Deprecated command aliases now include full command content (not just a redirect text). Old names execute identically to new names, with a one-line deprecation banner prepended.
+
+## [0.18.1] - 2026-03-30
+
+### Fixed
+
+- **Deprecated Aliases — Thin Redirects** — Converted deprecated alias files to thin redirects: content lives only in one place (new name), aliases point there. Eliminates duplication.
+
+## [0.18.0] - 2026-03-30
+
 ### Added
 
-- **Command Entry Point & Smart Router (2026-03-28)** — New `/effectum` entry point with `/help` alias; smart `/next` router that reads project state and recommends the single best next action.
-- **Namespace Reorganization (2026-03-28)** — Commands renamed for clarity: `/workshop:init` → `/project:init`, `/workshop:archive` → `/project:archive`, `/effectum:init` → `/context:init`. Deprecated old names still work with v0.20 removal notice.
-- **Command Aliases (2026-03-28)** — New convenience aliases: `/run` (→ `/tdd`), `/stop` (→ `/cancel-ralph`), `/save` (→ `/checkpoint`), `/diagnose` (→ `/forensics`), `/explore` (→ `/map-codebase`).
-- **Restructured Command README (2026-03-28)** — Updated `.claude/commands/README.md` with new hierarchical navigation: entry point (`/effectum`, `/help`, `/next`), core workflow, quality gates, git operations, loop control, orchestration, and setup categories.
+- **`effect:` / `effectum:` Namespace Split** — Commands reorganized into two clear namespaces: `effect:` for workflow commands (`effect:dev:run`, `effect:dev:tdd`, `effect:prd:new`, etc.) and `effectum:` for meta/setup commands (`effectum:setup`, `effectum:status`, `effectum:update`). Old names kept as deprecated aliases through v0.20.
+- **`effectum:status` Dashboard** — New command that prints a concise project health summary: version, active PRDs, loop state, test status, lint status, and git branch.
+- **`/ralph-loop` Permanent Name** — `/ralph-loop` is the canonical name for the autonomous development loop. Previous aliases (`/run-loop`, `/dev-loop`) deprecated.
+- **~38 Deprecated Aliases** — All renamed commands have backward-compatible aliases with migration notices. Removal target: v0.20.
+- **`MIGRATION.md`** — Documents all deprecated command names, their new names, and the v0.20 removal timeline.
 
 ### Changed
 
-- **Feature Intake Batch 2 (2026-03-28)** — Tracked three new feature signals: Description length capping in v2.1.86 (P1: cap to 250 chars), X-Claude-Code-Session-Id header support for API proxies (P2: watchlist), and improvements to `/skills` listing (docs-only).
-- **Effort Field on Commands** — Added `effort: "high"` annotation to `/ralph-loop` and `/orchestrate` commands to signal context-intensive operations.
-- **Agent-Ready Extension Fields in `/prd:new`** — Quality Gates, Completion Promise, and Autonomy Rules conditionally prompted in Step 5 for agent-facing specifications.
-- **Loop State Persistence** — `/cancel-ralph` now updates `.effectum/loop-state.json` with `status: "cancelled"` and `cancelled_at` timestamp for resumable workflows.
-- **Plan Output Automation** — `/plan` command now writes plan to `.claude/plan.local.md` with YAML frontmatter in new Step 7; subsequent steps renumbered.
+- **README** — Updated for v0.18 namespace clarity: new command table with `effect:`/`effectum:` prefixes, migration section.
+- **`.effectum.json` Command List** — Synced with new namespace names.
+
+## [0.17.8] - 2026-03-29
+
+### Changed
+
+- **Auto Mode Compatibility** — `/effectum` entry point and `/next` router updated for compatibility with Auto Mode spec (loop-worker preset, PRD #v018-autonomy-modes).
+
+## [0.17.7] - 2026-03-29
+
+_Patch: bug fixes from v0.17 journey analysis._
+
+## [0.17.6] - 2026-03-29
+
+_Patch: bug fixes from v0.17 journey analysis._
+
+## [0.17.5] - 2026-03-29
+
+_Patch: bug fixes from v0.17 journey analysis._
+
+## [0.17.4] - 2026-03-28
+
+_Patch: bug fixes from v0.17 journey analysis._
+
+## [0.17.3] - 2026-03-28
+
+_Patch: bug fixes from v0.17 journey analysis._
+
+## [0.17.2] - 2026-03-28
+
+_Patch: bug fixes from v0.17 journey analysis._
+
+## [0.17.1] - 2026-03-28
+
+_Patch: bug fixes from v0.17 journey analysis._
+
+## [0.17.0] - 2026-03-28
+
+### Added
+
+- **`/effectum` Entry Point** — New top-level command with `/help` alias. Single entry point for first-time users; links to all major workflow commands.
+- **`/next` Smart Router** — Reads project state (open PRDs, task registry, git status, test results) and recommends exactly one next action. First commit? → `/context:init`. PRD exists? → `/prd:task-breakdown`. Tests failing? → `/tdd`. One answer, always.
+- **Command Aliases** — New convenience aliases: `/run` (→ `/tdd`), `/stop` (→ `/cancel-ralph`), `/save` (→ `/checkpoint`), `/diagnose` (→ `/forensics`), `/explore` (→ `/map-codebase`).
+- **Restructured Command README** — Updated `.claude/commands/README.md` with hierarchical navigation: entry point, core workflow, quality gates, git operations, loop control, orchestration, setup.
+
+### Changed
+
+- **Namespace Reorganization** — Commands renamed for clarity: `/workshop:init` → `/project:init`, `/workshop:archive` → `/project:archive`, `/effectum:init` → `/context:init`. Deprecated old names still work with v0.20 removal notice.
+- **Effort Field on Commands** — Added `effort: "high"` to `/ralph-loop` and `/orchestrate`.
+- **Agent-Ready Extension Fields in `/prd:new`** — Quality Gates, Completion Promise, Autonomy Rules conditionally prompted for agent-facing specs.
+- **Loop State Persistence** — `/cancel-ralph` updates `.effectum/loop-state.json` with `status: "cancelled"` and `cancelled_at`.
+- **Plan Output Automation** — `/plan` writes plan to `.claude/plan.local.md` with YAML frontmatter.
 - **PRD Overlap Detection** — `/prd:new` reads existing PRDs in Step 2 for overlap detection.
-- **CLAUDE.md Sentinel Integration** — `/prd:new` reads CLAUDE.md sentinel for domain context during feature generation.
-- **Checkpoint Detection in `/ralph-loop`** — Detects checkpoint tags, stores in loop-state.json, mentions rollback in stuck handler.
-- **Task Registry Integration** — `/tdd` now integrates with task registry (reads on start, updates on completion).
-- **Debugger Agent Tags** — `debugger.md` agent now includes `tags: debugging, error-analysis, troubleshooting` for improved discoverability.
-
-### Changed
-
-- **Hook Conditionals in Templates** — Updated `settings.json.tmpl` templates to add `"if"` conditional fields: commit message validation only fires on `git commit*`, secret scanning fires on `git commit*` or `git push*`. Applied consistently across `.claude/settings.json`, `.effectum/templates/settings.json.tmpl`, and `system/templates/settings.json.tmpl`.
-- **README.md Command Tables** — Updated formatting for consistency in Loop Control and Setup & Brownfield sections; added descriptions for `/forensics`, `/effectum:init`, and `/map-codebase` to command reference tables.
-- **`/prd:handoff` Primary Next Step** — Now recommends `/ralph-loop` as the primary recommended next step for agentic workflows.
-- **`/prd:network-map` Sanitize Order** — Mermaid sanitize step moved before write (Steps 7→11 renumbered for clarity).
-- **`/workshop:archive` Path Format** — Fixed archive path to `workshop/archive/{date}_{slug}/` for consistent organization.
-- **Preset Stack Assignments** — `nextjs-firebase` and `nextjs-prisma` presets corrected from `nextjs-supabase` to `generic` (no matching stack files exist).
+- **CLAUDE.md Sentinel Integration** — `/prd:new` reads CLAUDE.md sentinel for domain context.
+- **Checkpoint Detection in `/ralph-loop`** — Detects checkpoint tags, stores in loop-state.json.
+- **Task Registry Integration** — `/tdd` integrates with task registry.
+- **Hook Conditionals** — `settings.json.tmpl`: commit message validation only fires on `git commit*`, secret scanning on `git commit*`/`git push*`.
+- **Debugger Agent Tags** — Added `tags: debugging, error-analysis, troubleshooting`.
+- **`/prd:handoff`** — Recommends `/ralph-loop` as primary next step.
+- **`/prd:network-map`** — Mermaid sanitize step moved before write.
+- **`/workshop:archive`** — Fixed archive path to `workshop/archive/{date}_{slug}/`.
+- **Preset Stack Assignments** — `nextjs-firebase` and `nextjs-prisma` corrected from `nextjs-supabase` to `generic`.
+- **Feature Intake** — Tracked signals: description length capping (P1), X-Claude-Code-Session-Id header (P2 watchlist), `/skills` listing improvements (docs-only).
 
 ## [0.16.0] - 2026-03-28
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ This isn't a new idea — it's the best combination of existing ideas I've found
 
 ---
 
+## Compatibility
+
+> **Note:** Claude Haiku 3 (claude-3-haiku-20240307) is deprecated by Anthropic as of April 19, 2026. Effectum users relying on Haiku 3 as a sub-agent or cost-saving model should migrate to claude-haiku-4-5 before that date.
+
+---
+
 ## 🚀 Quick Start
 
 ```bash
@@ -103,23 +109,23 @@ claude
 
 One command. Everything you need for autonomous Claude Code development.
 
-| What                          | Details |
-| ----------------------------- | ------- |
-| **Intelligent Configurator**  | Stack auto-detection, package manager config, 8 quick presets, 16 languages |
+| What                          | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Intelligent Configurator**  | Stack auto-detection, package manager config, 8 quick presets, 16 languages                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | **32 primary commands**       | `/effectum`, `effectum:setup`, `effectum:init`, `effectum:status`, `effectum:archive`, `effectum:onboard`, `effectum:onboard:review`, `effectum:explore`, `effect:next`, `effect:design`, `effect:prd:new`, `effect:prd:express`, `effect:prd:review`, `effect:prd:handoff`, `effect:prd:update`, `effect:prd:discuss`, `effect:prd:decompose`, `effect:prd:resume`, `effect:prd:status`, `effect:prd:network-map`, `effect:dev:run`, `effect:dev:stop`, `effect:dev:save`, `effect:dev:diagnose`, `effect:dev:plan`, `effect:dev:tdd`, `effect:dev:verify`, `effect:dev:review`, `effect:dev:e2e`, `effect:dev:fix`, `effect:dev:refactor`, `effect:dev:orchestrate` |
-| **Permanent aliases**         | `/ralph-loop` → `effect:dev:run`, `/help` → `/effectum` |
-| **Update Command**            | `npx @aslomon/effectum update` — add new commands, refresh templates, preserve config |
-| **PRD Lifecycle**             | Frontmatter, changelog, semantic diff, delta handoffs, task registry, network map auto-sync |
-| **Project Onboarding**        | 6 parallel analysis agents, 7-point self-test loop, per-area PRDs, interactive HTML network map |
-| **Design System Generation**  | `effect:design` generates DESIGN.md — color tokens, typography, component specs, constraints |
-| **25 Agent Specializations**  | Pre-configured agent roles with distinct behaviors for planning, TDD, review, security, and more |
-| **43+ Skills**                | Reusable capability blocks attached to agent roles |
-| **7 Stack Presets + 8 Quick** | Next.js+Supabase, Python+FastAPI, Swift/SwiftUI, Go+Echo, Django+PostgreSQL, Rust+Actix, Generic + Firebase, Prisma, Flutter… |
-| **YAML Frontmatter**          | All command files have machine-readable metadata (`name`, `description`, `allowed-tools`) |
-| **Quality gates**             | 8 automated checks (build, types, lint, tests, security, etc.) |
-| **Foundation Hooks**          | Always-on: secret detection, TDD enforcement, guardrails |
-| **Extensible**                | JSON-based tool definitions + detection rules, community presets + blocks |
-| **446 tests**                 | Comprehensive test suite covering configurator, templates, commands, frontmatter, and more |
+| **Permanent aliases**         | `/ralph-loop` → `effect:dev:run`, `/help` → `/effectum`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| **Update Command**            | `npx @aslomon/effectum update` — add new commands, refresh templates, preserve config                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **PRD Lifecycle**             | Frontmatter, changelog, semantic diff, delta handoffs, task registry, network map auto-sync                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| **Project Onboarding**        | 6 parallel analysis agents, 7-point self-test loop, per-area PRDs, interactive HTML network map                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| **Design System Generation**  | `effect:design` generates DESIGN.md — color tokens, typography, component specs, constraints                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| **25 Agent Specializations**  | Pre-configured agent roles with distinct behaviors for planning, TDD, review, security, and more                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| **43+ Skills**                | Reusable capability blocks attached to agent roles                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| **7 Stack Presets + 8 Quick** | Next.js+Supabase, Python+FastAPI, Swift/SwiftUI, Go+Echo, Django+PostgreSQL, Rust+Actix, Generic + Firebase, Prisma, Flutter…                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| **YAML Frontmatter**          | All command files have machine-readable metadata (`name`, `description`, `allowed-tools`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Quality gates**             | 8 automated checks (build, types, lint, tests, security, etc.)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| **Foundation Hooks**          | Always-on: secret detection, TDD enforcement, guardrails                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| **Extensible**                | JSON-based tool definitions + detection rules, community presets + blocks                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **446 tests**                 | Comprehensive test suite covering configurator, templates, commands, frontmatter, and more                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 ---
 
@@ -131,26 +137,26 @@ Effectum now has a cleaner mental model.
 
 Use these before or around development. They set up the environment, understand the codebase, and tell you the current state.
 
-| Command | What it does |
-| ------- | ------------ |
-| `effectum:setup` | Install Effectum workflow into a project |
-| `effectum:init` | Teach Claude about your domain and project conventions |
-| `effectum:status` | Project-health dashboard: version, stack, PRDs, loop status |
-| `effectum:archive` | Archive a completed project |
-| `effectum:onboard` | Full codebase analysis with 6 parallel agents + self-test loop |
-| `effectum:onboard:review` | Re-run onboarding review after significant changes |
-| `effectum:explore` | Fast brownfield analysis with 4 parallel agents and structured docs |
+| Command                   | What it does                                                        |
+| ------------------------- | ------------------------------------------------------------------- |
+| `effectum:setup`          | Install Effectum workflow into a project                            |
+| `effectum:init`           | Teach Claude about your domain and project conventions              |
+| `effectum:status`         | Project-health dashboard: version, stack, PRDs, loop status         |
+| `effectum:archive`        | Archive a completed project                                         |
+| `effectum:onboard`        | Full codebase analysis with 6 parallel agents + self-test loop      |
+| `effectum:onboard:review` | Re-run onboarding review after significant changes                  |
+| `effectum:explore`        | Fast brownfield analysis with 4 parallel agents and structured docs |
 
 ### `effect:*` — Pipeline Sphere
 
 Use these while building. They move a feature from idea to spec to production-ready code.
 
-| Area | Commands |
-| ---- | -------- |
-| **Navigation** | `effect:next` |
-| **PRD pipeline** | `effect:prd:new`, `effect:prd:express`, `effect:prd:review`, `effect:prd:handoff`, `effect:prd:update`, `effect:prd:discuss`, `effect:prd:decompose`, `effect:prd:resume`, `effect:prd:status`, `effect:prd:network-map` |
+| Area             | Commands                                                                                                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Navigation**   | `effect:next`                                                                                                                                                                                                                                     |
+| **PRD pipeline** | `effect:prd:new`, `effect:prd:express`, `effect:prd:review`, `effect:prd:handoff`, `effect:prd:update`, `effect:prd:discuss`, `effect:prd:decompose`, `effect:prd:resume`, `effect:prd:status`, `effect:prd:network-map`                          |
 | **Dev pipeline** | `effect:dev:run`, `effect:dev:stop`, `effect:dev:save`, `effect:dev:diagnose`, `effect:dev:plan`, `effect:dev:tdd`, `effect:dev:verify`, `effect:dev:review`, `effect:dev:e2e`, `effect:dev:fix`, `effect:dev:refactor`, `effect:dev:orchestrate` |
-| **Standalone** | `effect:design`, `effect:next` |
+| **Standalone**   | `effect:design`, `effect:next`                                                                                                                                                                                                                    |
 
 > [!TIP]
 > Old names still work until v0.20, but the documentation now uses the canonical v0.18 namespace everywhere.
@@ -307,56 +313,56 @@ The namespace is now simple: **System** with `effectum:*`, **Pipeline** with `ef
 
 ### System Commands (`effectum:*`)
 
-| Command | What it does |
-| ------- | ------------ |
-| `effectum:setup` | Install Effectum workflow into a project |
-| `effectum:init` | Interactive interview to populate project context in `CLAUDE.md` |
-| `effectum:status` | Project dashboard: installed version, stack, autonomy level, PRDs, health |
-| `effectum:onboard` | Full codebase analysis with 6 parallel agents + self-test loop |
-| `effectum:onboard:review` | Re-run onboarding review after significant changes |
-| `effectum:explore` | 4 parallel agents → 7 structured knowledge docs for brownfield codebases |
-| `effectum:archive` | Archive a completed project |
+| Command                   | What it does                                                              |
+| ------------------------- | ------------------------------------------------------------------------- |
+| `effectum:setup`          | Install Effectum workflow into a project                                  |
+| `effectum:init`           | Interactive interview to populate project context in `CLAUDE.md`          |
+| `effectum:status`         | Project dashboard: installed version, stack, autonomy level, PRDs, health |
+| `effectum:onboard`        | Full codebase analysis with 6 parallel agents + self-test loop            |
+| `effectum:onboard:review` | Re-run onboarding review after significant changes                        |
+| `effectum:explore`        | 4 parallel agents → 7 structured knowledge docs for brownfield codebases  |
+| `effectum:archive`        | Archive a completed project                                               |
 
 ### Pipeline Commands (`effect:*`)
 
 #### PRD Pipeline (`effect:prd:*`)
 
-| Command | What it does |
-| ------- | ------------ |
-| `effect:prd:new` | Start a new specification (guided workshop) |
-| `effect:prd:express` | Quick PRD from structured input |
-| `effect:prd:discuss` | Deep-dive discussion for a specific PRD |
-| `effect:prd:decompose` | Split large scope into multiple PRDs |
-| `effect:prd:update` | Evolve an existing spec — tracks changes semantically |
-| `effect:prd:review` | Quality check — is this spec ready for implementation? |
-| `effect:prd:handoff` | Delta handoff export for implementation (`--prompt-only` supported) |
-| `effect:prd:resume` | Resume work on an existing project/PRD |
-| `effect:prd:status` | Dashboard of all projects and PRDs |
-| `effect:prd:network-map` | Render PRD dependencies as interactive HTML map |
+| Command                  | What it does                                                        |
+| ------------------------ | ------------------------------------------------------------------- |
+| `effect:prd:new`         | Start a new specification (guided workshop)                         |
+| `effect:prd:express`     | Quick PRD from structured input                                     |
+| `effect:prd:discuss`     | Deep-dive discussion for a specific PRD                             |
+| `effect:prd:decompose`   | Split large scope into multiple PRDs                                |
+| `effect:prd:update`      | Evolve an existing spec — tracks changes semantically               |
+| `effect:prd:review`      | Quality check — is this spec ready for implementation?              |
+| `effect:prd:handoff`     | Delta handoff export for implementation (`--prompt-only` supported) |
+| `effect:prd:resume`      | Resume work on an existing project/PRD                              |
+| `effect:prd:status`      | Dashboard of all projects and PRDs                                  |
+| `effect:prd:network-map` | Render PRD dependencies as interactive HTML map                     |
 
 #### Dev Pipeline (`effect:dev:*`)
 
-| Command | What it does |
-| ------- | ------------ |
-| `effect:dev:plan` | Read spec, explore codebase, produce a plan — **waits for your OK** |
-| `effect:dev:tdd` | Failing test → passing code → refactor → repeat |
-| `effect:dev:verify` | Run all 8 quality gates |
-| `effect:dev:review` | Security audit, architecture review, rating by severity |
-| `effect:dev:e2e` | End-to-end test run with Playwright |
-| `effect:dev:fix` | Targeted fix loop for a specific failing build or test |
-| `effect:dev:refactor` | Clean up code without changing behavior |
-| `effect:dev:run` | Autonomous build loop — writes, tests, fixes, iterates until done |
-| `effect:dev:stop` | Stop the loop cleanly, preserve state |
-| `effect:dev:save` | Snapshot current state (git + test results + notes) |
-| `effect:dev:diagnose` | Post-mortem diagnosis — reads loop artifacts and produces failure report |
-| `effect:dev:orchestrate` | Parallel agent teams (opt-in) |
+| Command                  | What it does                                                             |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `effect:dev:plan`        | Read spec, explore codebase, produce a plan — **waits for your OK**      |
+| `effect:dev:tdd`         | Failing test → passing code → refactor → repeat                          |
+| `effect:dev:verify`      | Run all 8 quality gates                                                  |
+| `effect:dev:review`      | Security audit, architecture review, rating by severity                  |
+| `effect:dev:e2e`         | End-to-end test run with Playwright                                      |
+| `effect:dev:fix`         | Targeted fix loop for a specific failing build or test                   |
+| `effect:dev:refactor`    | Clean up code without changing behavior                                  |
+| `effect:dev:run`         | Autonomous build loop — writes, tests, fixes, iterates until done        |
+| `effect:dev:stop`        | Stop the loop cleanly, preserve state                                    |
+| `effect:dev:save`        | Snapshot current state (git + test results + notes)                      |
+| `effect:dev:diagnose`    | Post-mortem diagnosis — reads loop artifacts and produces failure report |
+| `effect:dev:orchestrate` | Parallel agent teams (opt-in)                                            |
 
 #### Standalone Pipeline Commands
 
-| Command | What it does |
-| ------- | ------------ |
+| Command         | What it does                                                     |
+| --------------- | ---------------------------------------------------------------- |
 | `effect:design` | Generate `DESIGN.md` — color tokens, typography, component specs |
-| `effect:next` | Read project state and recommend the single best next action |
+| `effect:next`   | Read project state and recommend the single best next action     |
 
 > [!TIP]
 > See the full [Command Index](system/commands/README.md) for all commands organized by sphere and namespace.
@@ -432,14 +438,14 @@ effect:dev:diagnose
 
 It reads all available loop artifacts and produces a structured diagnosis report:
 
-| Artifact                    | What it reveals |
-| --------------------------- | --------------- |
-| `HANDOFF.md`                | Context budget stop — what was done, what's left |
-| `STUCK.md`                  | Stuck detection report — the repeated error and diagnosis |
-| `.effectum/loop-state.json` | Last persisted iteration state |
-| `effectum-metrics.json`     | Historical session ledger |
-| `.claude/ralph-loop.local.md` | Internal loop state |
-| `.claude/ralph-blockers.md` | Documented blockers |
+| Artifact                      | What it reveals                                           |
+| ----------------------------- | --------------------------------------------------------- |
+| `HANDOFF.md`                  | Context budget stop — what was done, what's left          |
+| `STUCK.md`                    | Stuck detection report — the repeated error and diagnosis |
+| `.effectum/loop-state.json`   | Last persisted iteration state                            |
+| `effectum-metrics.json`       | Historical session ledger                                 |
+| `.claude/ralph-loop.local.md` | Internal loop state                                       |
+| `.claude/ralph-blockers.md`   | Documented blockers                                       |
 
 The output is a root-cause diagnosis with a recommended next action — whether that's fixing the blocker, resuming from checkpoint, or rewriting a failing test.
 
@@ -476,12 +482,12 @@ This is the right command to run before `effect:dev:run` on a new project, or be
 effectum:explore
 ```
 
-| Agent | Output document |
-| ----- | --------------- |
+| Agent                  | Output document                                    |
+| ---------------------- | -------------------------------------------------- |
 | **ArchitectureMapper** | `ARCHITECTURE.md` — structure, modules, boundaries |
-| **DataFlowMapper** | `DATA-FLOW.md` — how data moves through the system |
-| **APIMapper** | `API-SURFACE.md` — all endpoints, contracts, auth |
-| **DependencyMapper** | `DEPENDENCIES.md` — packages, versions, risk flags |
+| **DataFlowMapper**     | `DATA-FLOW.md` — how data moves through the system |
+| **APIMapper**          | `API-SURFACE.md` — all endpoints, contracts, auth  |
+| **DependencyMapper**   | `DEPENDENCIES.md` — packages, versions, risk flags |
 
 Plus three synthesis documents: `ENTRY-POINTS.md`, `RISK-MAP.md`, and `KNOWLEDGE-INDEX.md`.
 
@@ -574,11 +580,11 @@ When you run `npx @aslomon/effectum update`, the system-managed section is refre
 
 Foundation hooks now support richer configuration:
 
-| Feature | Example |
-| ------- | ------- |
-| **Conditional `if:`** | Run a hook only when specific files are staged |
-| **Multi-glob** | Match multiple file patterns in a single hook rule |
-| **`effort:` level** | Tag commands as `low`, `medium`, or `high` effort for context budgeting |
+| Feature               | Example                                                                 |
+| --------------------- | ----------------------------------------------------------------------- |
+| **Conditional `if:`** | Run a hook only when specific files are staged                          |
+| **Multi-glob**        | Match multiple file patterns in a single hook rule                      |
+| **`effort:` level**   | Tag commands as `low`, `medium`, or `high` effort for context budgeting |
 
 Hooks remain always-active for the three core guardrails (secret detection, TDD enforcement, destructive command blocking). The new features apply to custom hooks you add in `system/hooks/`.
 
@@ -586,16 +592,16 @@ Hooks remain always-active for the three core guardrails (secret detection, TDD 
 
 ### `effect:dev:verify` — Every quality gate, every time
 
-| Gate | What it checks | Standard |
-| ---- | -------------- | -------- |
-| 🔨 Build | Compiles without errors | 0 errors |
-| 📐 Types | Type safety | 0 errors |
-| 🧹 Lint | Clean code style | 0 warnings |
-| 🧪 Tests | Test suite | All pass, 80%+ coverage |
-| 🔒 Security | OWASP vulnerabilities | None found |
-| 🚫 Debug logs | `console.log` in production | 0 occurrences |
-| 🛡️ Type safety | `any` or unsafe casts | None |
-| 📏 File size | Oversized files | Max 300 lines |
+| Gate           | What it checks              | Standard                |
+| -------------- | --------------------------- | ----------------------- |
+| 🔨 Build       | Compiles without errors     | 0 errors                |
+| 📐 Types       | Type safety                 | 0 errors                |
+| 🧹 Lint        | Clean code style            | 0 warnings              |
+| 🧪 Tests       | Test suite                  | All pass, 80%+ coverage |
+| 🔒 Security    | OWASP vulnerabilities       | None found              |
+| 🚫 Debug logs  | `console.log` in production | 0 occurrences           |
+| 🛡️ Type safety | `any` or unsafe casts       | None                    |
+| 📏 File size   | Oversized files             | Max 300 lines           |
 
 ---
 
@@ -652,14 +658,14 @@ $ npx @aslomon/effectum update
 
 The configurator now auto-detects your package manager from lock files and recommends the best option for your ecosystem.
 
-| Lock file detected | Package manager |
-| ------------------ | --------------- |
+| Lock file detected | Package manager    |
+| ------------------ | ------------------ |
 | `pnpm-lock.yaml`   | pnpm (recommended) |
-| `yarn.lock`        | yarn |
-| `bun.lockb`        | bun |
-| `uv.lock`          | uv |
-| `Cargo.lock`       | cargo |
-| `go.sum`           | go |
+| `yarn.lock`        | yarn               |
+| `bun.lockb`        | bun                |
+| `uv.lock`          | uv                 |
+| `Cargo.lock`       | cargo              |
+| `go.sum`           | go                 |
 
 - **Apple-like flow**: detected package manager → confirm or change
 - **Ecosystem-aware defaults**: pnpm for JS, uv for Python, cargo for Rust, go for Go
@@ -777,14 +783,14 @@ docs/network-map.html  ← open in browser, zoom, click nodes
 
 Run `effectum:onboard` in any project directory. Effectum spawns **6 parallel analysis agents**, each with a specific lens:
 
-| Agent | Focus |
-| ----- | ----- |
-| 🏗️ **Architecture** | Directory structure, module boundaries, dependency graph |
-| 🗄️ **Data Model** | Schemas, migrations, RLS policies, relationships |
-| 🔌 **API Surface** | Endpoints, contracts, authentication patterns |
-| 🧪 **Test Coverage** | What's tested, what's not, test quality assessment |
-| 🔒 **Security** | Auth flows, secret handling, known vulnerability patterns |
-| 📦 **Dependencies** | Packages, versions, outdated or risky dependencies |
+| Agent                | Focus                                                     |
+| -------------------- | --------------------------------------------------------- |
+| 🏗️ **Architecture**  | Directory structure, module boundaries, dependency graph  |
+| 🗄️ **Data Model**    | Schemas, migrations, RLS policies, relationships          |
+| 🔌 **API Surface**   | Endpoints, contracts, authentication patterns             |
+| 🧪 **Test Coverage** | What's tested, what's not, test quality assessment        |
+| 🔒 **Security**      | Auth flows, secret handling, known vulnerability patterns |
+| 📦 **Dependencies**  | Packages, versions, outdated or risky dependencies        |
 
 ### Self-Test Loop (7 Tests)
 
@@ -831,15 +837,15 @@ docs/
 
 Effectum ships with pre-configured agent roles. Each has a distinct behavior profile, toolset, and communication style appropriate to its function:
 
-| Category | Agents |
-| -------- | ------ |
-| **Planning** | Architect, Decomposer, Risk Analyst |
-| **Build** | Engineer, TDD Driver, Refactor Specialist, Fullstack Developer, Next.js Developer |
-| **Quality** | QA Reviewer, Security Auditor, Performance Analyst, Code Reviewer |
-| **Documentation** | Spec Writer, API Documenter, Onboarding Analyst |
-| **Orchestration** | Ralph (autonomous loop), Checkpoint Manager, Delta Tracker |
-| **Analysis** | Architecture Analyst, DB Analyst, API Analyst, Frontend Analyst, Stack Analyst, Test Analyst |
-| **Specialist** | Mobile Developer, Docker Expert, MCP Developer, Postgres Pro, Data Engineer, Debugger, UI Designer |
+| Category          | Agents                                                                                             |
+| ----------------- | -------------------------------------------------------------------------------------------------- |
+| **Planning**      | Architect, Decomposer, Risk Analyst                                                                |
+| **Build**         | Engineer, TDD Driver, Refactor Specialist, Fullstack Developer, Next.js Developer                  |
+| **Quality**       | QA Reviewer, Security Auditor, Performance Analyst, Code Reviewer                                  |
+| **Documentation** | Spec Writer, API Documenter, Onboarding Analyst                                                    |
+| **Orchestration** | Ralph (autonomous loop), Checkpoint Manager, Delta Tracker                                         |
+| **Analysis**      | Architecture Analyst, DB Analyst, API Analyst, Frontend Analyst, Stack Analyst, Test Analyst       |
+| **Specialist**    | Mobile Developer, Docker Expert, MCP Developer, Postgres Pro, Data Engineer, Debugger, UI Designer |
 
 Each specialization is defined in `system/agents/` and composed from shared skills.
 
@@ -847,23 +853,23 @@ Each specialization is defined in `system/agents/` and composed from shared skil
 
 Skills are reusable capability blocks that agent specializations are composed from:
 
-| Domain | Examples |
-| ------ | -------- |
-| **Code** | TypeScript, Python, Go, Swift, Rust, SQL |
-| **Testing** | TDD, E2E, snapshot, load testing |
-| **Security** | Secret detection, OWASP scanning, RLS validation |
-| **Documentation** | PRD authoring, markdown, Mermaid diagrams |
-| **Infrastructure** | Vercel, Railway, Fly.io, Docker, GitHub Actions |
+| Domain             | Examples                                         |
+| ------------------ | ------------------------------------------------ |
+| **Code**           | TypeScript, Python, Go, Swift, Rust, SQL         |
+| **Testing**        | TDD, E2E, snapshot, load testing                 |
+| **Security**       | Secret detection, OWASP scanning, RLS validation |
+| **Documentation**  | PRD authoring, markdown, Mermaid diagrams        |
+| **Infrastructure** | Vercel, Railway, Fly.io, Docker, GitHub Actions  |
 
 ### Foundation Hooks (Always Active)
 
 Three hooks run on every Claude Code session, regardless of configuration:
 
-| Hook | What it does |
-| ---- | ------------ |
+| Hook                 | What it does                                                     |
+| -------------------- | ---------------------------------------------------------------- |
 | **Secret Detection** | Blocks writes containing API keys, tokens, passwords to any file |
-| **TDD Enforcement** | Warns when code is written before a failing test exists |
-| **Guardrails** | Prevents `rm -rf`, `DROP TABLE`, direct writes to `.env` |
+| **TDD Enforcement**  | Warns when code is written before a failing test exists          |
+| **Guardrails**       | Prevents `rm -rf`, `DROP TABLE`, direct writes to `.env`         |
 
 These can't be disabled by mistake. They're the safety net.
 
@@ -940,12 +946,12 @@ Pull requests for new stacks, presets, and detection rules are especially welcom
 
 ## 🆚 How is this different?
 
-| Tool | What it does | What Effectum adds / differs |
-| ---- | ------------ | ---------------------------- |
-| **GSD** | Context engineering, prevents context rot | PRD Lifecycle (spec versioning + delta handoffs), autonomous loop, Project Onboarding |
-| **BMAD** | Full enterprise methodology | Same ideas, 90% less ceremony. Configurator auto-selects what's relevant. |
-| **SpecKit** | Living specifications | + Autonomous execution + Quality gates + Task registry + Network map |
-| **Taskmaster** | Task breakdown from PRDs | + TDD workflow + Code review + E2E testing + Semantic diff + Onboarding agents |
+| Tool           | What it does                              | What Effectum adds / differs                                                            |
+| -------------- | ----------------------------------------- | --------------------------------------------------------------------------------------- |
+| **GSD**        | Context engineering, prevents context rot | PRD Lifecycle (spec versioning + delta handoffs), autonomous loop, Project Onboarding   |
+| **BMAD**       | Full enterprise methodology               | Same ideas, 90% less ceremony. Configurator auto-selects what's relevant.               |
+| **SpecKit**    | Living specifications                     | + Autonomous execution + Quality gates + Task registry + Network map                    |
+| **Taskmaster** | Task breakdown from PRDs                  | + TDD workflow + Code review + E2E testing + Semantic diff + Onboarding agents          |
 | **Kiro (AWS)** | IDE-native spec-driven dev (VS Code fork) | CLI-native. No IDE required. No opaque request pricing. Works with your existing setup. |
 
 The short version: Effectum doesn't invent new concepts. It combines what already works, removes what doesn't, and packages it so it actually runs.
@@ -1033,16 +1039,16 @@ Customize everything<br>
 
 ### Quick Presets (Add-Ons)
 
-| Quick Preset | Adds to your stack |
-| ------------ | ------------------ |
-| **+ Firebase** | Firebase SDK, Firestore rules, Auth integration patterns |
-| **+ Prisma** | Prisma schema, migration workflow, typed client |
-| **+ Flutter** | Dart/Flutter project config, widget test setup |
-| **+ Stripe** | Webhook handling patterns, price/subscription management |
-| **+ tRPC** | End-to-end typesafe API layer |
-| **+ Turborepo** | Monorepo workspace configuration |
-| **+ Docker** | Dockerfile, docker-compose, health check patterns |
-| **+ GitHub CI** | GitHub Actions workflow for test + deploy |
+| Quick Preset    | Adds to your stack                                       |
+| --------------- | -------------------------------------------------------- |
+| **+ Firebase**  | Firebase SDK, Firestore rules, Auth integration patterns |
+| **+ Prisma**    | Prisma schema, migration workflow, typed client          |
+| **+ Flutter**   | Dart/Flutter project config, widget test setup           |
+| **+ Stripe**    | Webhook handling patterns, price/subscription management |
+| **+ tRPC**      | End-to-end typesafe API layer                            |
+| **+ Turborepo** | Monorepo workspace configuration                         |
+| **+ Docker**    | Dockerfile, docker-compose, health check patterns        |
+| **+ GitHub CI** | GitHub Actions workflow for test + deploy                |
 
 Each preset configures build commands, test frameworks, linters, formatters, and architecture rules for your stack.
 
@@ -1052,13 +1058,13 @@ Each preset configures build commands, test frameworks, linters, formatters, and
 
 Choose how much Claude decides on its own:
 
-|                           | Conservative | Standard | Full Autonomy |
-| ------------------------- | :----------: | :------: | :-----------: |
-| **Claude asks before...** | Most changes | Ambiguous specs | Almost nothing |
-| **Git operations**        | Always asks | Asks for push | Autonomous |
-| **File changes**          | Confirms each | Works freely | Works freely |
-| **Best for**              | Teams, learning | Daily dev | Overnight builds |
-| **Autonomous loop**       | ❌ | ✅ | ✅ Recommended |
+|                           |  Conservative   |    Standard     |  Full Autonomy   |
+| ------------------------- | :-------------: | :-------------: | :--------------: |
+| **Claude asks before...** |  Most changes   | Ambiguous specs |  Almost nothing  |
+| **Git operations**        |   Always asks   |  Asks for push  |    Autonomous    |
+| **File changes**          |  Confirms each  |  Works freely   |   Works freely   |
+| **Best for**              | Teams, learning |    Daily dev    | Overnight builds |
+| **Autonomous loop**       |       ❌        |       ✅        |  ✅ Recommended  |
 
 Choose during setup. Change anytime in `.claude/settings.json`.
 
@@ -1117,14 +1123,14 @@ effectum/
 
 ## 📚 Documentation
 
-| Guide | What you'll learn |
-| ----- | ----------------- |
-| 📖 [Workflow Overview](docs/workflow-overview.md) | The complete autonomous workflow explained |
-| ⚙️ [Configurator Guide](docs/configurator-guide.md) | Stack detection, presets, language setup |
-| 📋 [PRD Lifecycle](docs/prd-lifecycle.md) | Frontmatter, diffs, delta handoffs, tasks.md |
-| 🔍 [Onboarding Guide](docs/onboarding-guide.md) | Getting up to speed on any codebase fast |
-| 🔧 [Customization](docs/customization.md) | JSON tools, detection rules, community presets |
-| 🔍 [Troubleshooting](docs/troubleshooting.md) | Common issues and solutions |
+| Guide                                               | What you'll learn                              |
+| --------------------------------------------------- | ---------------------------------------------- |
+| 📖 [Workflow Overview](docs/workflow-overview.md)   | The complete autonomous workflow explained     |
+| ⚙️ [Configurator Guide](docs/configurator-guide.md) | Stack detection, presets, language setup       |
+| 📋 [PRD Lifecycle](docs/prd-lifecycle.md)           | Frontmatter, diffs, delta handoffs, tasks.md   |
+| 🔍 [Onboarding Guide](docs/onboarding-guide.md)     | Getting up to speed on any codebase fast       |
+| 🔧 [Customization](docs/customization.md)           | JSON tools, detection rules, community presets |
+| 🔍 [Troubleshooting](docs/troubleshooting.md)       | Common issues and solutions                    |
 
 ---
 

--- a/docs/prds/intake-022-defer-permission.md
+++ b/docs/prds/intake-022-defer-permission.md
@@ -1,0 +1,174 @@
+# Spec: Defer Permission Decision via PreToolUse Hook
+
+**Intake:** #022  
+**Signal:** Claude Code v2.1.89 — `PreToolUse` hooks can now return `"defer"` as a `permissionDecision`. This pauses the headless session, which can be resumed via `claude -p --resume <session-id>`.  
+**Priority:** P1  
+**Roadmap:** v0.17  
+**Status:** Draft (2026-04-02)
+
+---
+
+## Problem
+
+Headless and autonomous runs (`/ralph-loop`, CI pipelines) currently have two extremes for handling sensitive operations:
+
+1. **Allow** — auto-approve everything matching a pattern (via `headless-approver.sh`). Fast, but risky for destructive commands.
+2. **Deny** — block the operation entirely. Safe, but the loop fails and the session cannot continue from where it stopped.
+
+Neither option supports a "pause and let a human review before continuing" workflow. When an autonomous run encounters a destructive command (`rm -rf`, `DROP TABLE`, `git push --force`), the only choices are to silently approve it or kill the session. There is no way to freeze the session, notify a human, wait for review, and resume exactly where it left off.
+
+This is the missing middle path: **defer**.
+
+---
+
+## Solution: `defer` Permission Decision
+
+Claude Code v2.1.89 adds `"defer"` as a valid `permissionDecision` return value from `PreToolUse` hooks. When a hook returns `defer`:
+
+1. The headless session **pauses** (does not exit, does not fail).
+2. The session ID is preserved and can be resumed with `claude -p --resume <session-id>`.
+3. The human reviews the pending operation, then resumes the session — at which point Claude Code re-evaluates the tool call.
+
+This enables human-in-the-loop checkpoints during autonomous runs without losing session state.
+
+---
+
+## Specification
+
+### New Config Flag: `defer-on-destructive`
+
+Add a `deferOnDestructive` flag to `.effectum/config.json` under the `autonomy` section:
+
+```json
+{
+  "autonomy": {
+    "level": "full",
+    "headless": true,
+    "deferOnDestructive": true
+  }
+}
+```
+
+When `deferOnDestructive: true`, `effectum:setup` and `effectum update` inject a `PreToolUse` hook that returns `"defer"` for destructive command patterns instead of `"deny"`.
+
+### PreToolUse Hook: `defer-on-destructive`
+
+Location: injected into `.claude/settings.json` under `hooks.PreToolUse`, alongside the existing `headless-approver` hook.
+
+```json
+{
+  "matcher": "Bash",
+  "if": "{{EFFECTUM_HEADLESS}}",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "bash -c 'source .effectum/defer-destructive.sh'",
+      "statusMessage": "Checking for destructive operations..."
+    }
+  ]
+}
+```
+
+### Defer Script: `.effectum/defer-destructive.sh`
+
+This script receives the tool input via stdin (JSON) and returns `defer` for destructive patterns:
+
+```bash
+#!/usr/bin/env bash
+# .effectum/defer-destructive.sh
+# Returns "defer" for destructive command patterns during headless runs.
+# The session pauses until a human resumes it with: claude -p --resume <id>
+
+input=$(cat)
+
+cmd=$(echo "$input" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(d.get('input',{}).get('command',''))" \
+  2>/dev/null)
+
+# Destructive patterns that require human review
+if echo "$cmd" | grep -qEi \
+  "(rm\s+(-rf|--force)|DROP\s+(TABLE|DATABASE|SCHEMA)|TRUNCATE|DELETE\s+FROM|git\s+push\s+--force|git\s+reset\s+--hard|--dangerously)"; then
+  echo '{"permissionDecision":"defer","message":"Destructive operation detected. Session paused for human review. Resume with: claude -p --resume <session-id>"}'
+  exit 0
+fi
+
+# Non-destructive — pass through (no decision, let other hooks handle)
+exit 0
+```
+
+### Integration with Existing Scripts
+
+**`headless-approver.sh`** — No changes needed. The defer script runs as a separate `PreToolUse` hook with a `Bash` matcher. It evaluates before the general headless-approver. Hook ordering:
+
+1. `defer-destructive.sh` — catches destructive patterns, returns `defer`
+2. `headless-approver.sh` — auto-approves known-safe patterns, denies the rest
+
+**`permission-denied-handler.sh`** — When `deferOnDestructive` is enabled, destructive operations no longer hit the deny path. The permission-denied handler still catches any remaining denials from the headless-approver whitelist.
+
+### Resume Flow
+
+When a session is deferred:
+
+```
+[Ralph Loop running autonomously]
+  ↓
+[Destructive command detected: rm -rf dist/]
+  ↓
+[Hook returns "defer" → session pauses]
+  ↓
+[Notification sent (desktop/Slack/webhook — via existing notification hooks)]
+  ↓
+[Human reviews: "claude -p --resume abc123"]
+  ↓
+[Session resumes, Claude re-evaluates the tool call]
+```
+
+### Environment Variables
+
+| Variable                     | Purpose                                                                    |
+| ---------------------------- | -------------------------------------------------------------------------- |
+| `EFFECTUM_HEADLESS`          | Enables headless mode (existing)                                           |
+| `EFFECTUM_DEFER_DESTRUCTIVE` | Enables defer-on-destructive (optional override, defaults to config value) |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `effectum:setup` accepts `--defer-on-destructive` flag; sets `autonomy.deferOnDestructive: true` in config
+- [ ] `effectum update` injects `defer-destructive` PreToolUse hook when `deferOnDestructive: true`
+- [ ] `defer-destructive.sh` returns `{"permissionDecision":"defer"}` for: `rm -rf`, `DROP TABLE`, `DELETE FROM`, `TRUNCATE`, `git push --force`, `git reset --hard`
+- [ ] Non-destructive commands pass through to `headless-approver.sh` without interference
+- [ ] Deferred sessions can be resumed with `claude -p --resume <session-id>` and continue from the exact point of deferral
+- [ ] Defer message includes the session ID and resume command in the output
+- [ ] Hook is NOT injected when `deferOnDestructive: false` (default) — zero impact on existing setups
+- [ ] `EFFECTUM_DEFER_DESTRUCTIVE` env var overrides config for one-shot CI runs
+- [ ] Works correctly alongside `headless-approver.sh` (no hook conflicts)
+- [ ] Template documented in `docs/command-schema.md` and `docs/hooks.md`
+
+---
+
+## Non-Goals
+
+- No custom defer patterns in this version — only the built-in destructive pattern list. Custom patterns are a follow-up.
+- No automatic resume (e.g., after timeout). Defer always requires explicit human action.
+- No Slack/webhook integration for defer notifications in this spec — use existing notification hooks.
+- No changes to the `--dangerously-skip-permissions` flag. Defer is orthogonal to that escape hatch.
+
+---
+
+## Implementation Notes
+
+- `permissionDecision: "defer"` requires Claude Code ≥ v2.1.89
+- `--resume <session-id>` requires Claude Code ≥ v2.1.89
+- The defer script should be committed to the repo so CI environments have consistent behavior
+- Hook ordering matters: the `defer-destructive` hook must run before `headless-approver` to catch destructive patterns before they hit the allow/deny logic
+- Add `EFFECTUM_DEFER_DESTRUCTIVE` to `.env.effectum.example` with comment
+
+---
+
+## Open Questions
+
+1. **Hook ordering guarantees** — Does Claude Code execute `PreToolUse` hooks in the order they appear in `settings.json`? If not, how do we ensure `defer-destructive` runs before `headless-approver`?
+2. **Session ID availability** — Can the hook script access the current session ID to include it in the defer message, or must the user find it from the Claude Code output?
+3. **Extend to Write/Edit?** — Should destructive file operations (overwriting `.env`, deleting migrations) also trigger defer? Current spec only covers Bash commands.
+4. **Custom pattern list** — v0.18 follow-up: let users define their own defer patterns in `.effectum/config.json`.

--- a/docs/prds/intake-024-powerup-onboarding.md
+++ b/docs/prds/intake-024-powerup-onboarding.md
@@ -1,0 +1,115 @@
+# Spec: Powerup Onboarding Integration
+
+**Intake:** #024  
+**Signal:** Claude Code v2.1.90 — `/powerup` command added: in-app onboarding with animated terminal demos for Claude Code features.  
+**Priority:** P1  
+**Roadmap:** v0.20  
+**Status:** Draft (2026-04-02)
+
+---
+
+## Problem
+
+New Effectum users go through `effectum:onboard` or `effectum:setup` and get a fully configured project — but they may not know what Claude Code itself can do. There is a gap between "Effectum is installed" and "I understand the Claude Code features that make Effectum powerful."
+
+Claude Code's new `/powerup` command fills this gap with animated terminal demos that teach core features. Effectum should bridge users to it as a natural follow-on step after onboarding.
+
+Additionally, Effectum has its own learning curve (`/ralph-loop`, `effect:dev:run`, `effect:prd:new`, etc.) that `/powerup` does not cover. There is an opportunity for Effectum-specific "powerup" lessons.
+
+---
+
+## Solution
+
+Two changes:
+
+1. **Reference `/powerup` in the onboarding flow** — after `effectum:onboard` or `effectum:setup` completes, suggest `/powerup` as a next step for users new to Claude Code.
+2. **Effectum-specific lessons** (future) — create Effectum-native powerup content that teaches the Effectum workflow commands.
+
+---
+
+## Specification
+
+### Phase 1: `/powerup` Reference in Onboarding
+
+After `effectum:onboard` or `effectum:setup` completes successfully, append a "Learn More" section to the completion output:
+
+```
+✔ Effectum setup complete.
+
+📚 Next steps:
+  1. Run effect:prd:new to write your first specification
+  2. Run effect:dev:plan to create an implementation plan
+  3. Run /powerup to learn Claude Code features (animated demos)
+```
+
+**Implementation:** Add the `/powerup` suggestion to the completion message templates in:
+
+- `commands/effectum-onboard.md` — post-onboarding output
+- `commands/effectum-setup.md` — post-setup output (interactive configurator)
+- `commands/effectum.md` — the `/effectum` front door help text
+
+### Phase 2: Effectum Powerup Lessons (Future)
+
+Create Effectum-specific interactive lessons that teach the core workflow:
+
+| Lesson                 | Teaches                                                                       |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| **The Effectum Loop**  | `effect:prd:new` → `effect:dev:plan` → `effect:dev:run` → `effect:dev:verify` |
+| **Ralph Loop**         | What `/ralph-loop` does, how to monitor it, when to stop it                   |
+| **PRD Lifecycle**      | Creating, updating, reviewing, and handing off PRDs                           |
+| **Project Onboarding** | Using `effectum:onboard` on an existing codebase                              |
+| **Recovery**           | `effect:dev:save`, `effect:dev:diagnose`, resuming crashed sessions           |
+
+**Format considerations:**
+
+- If Claude Code exposes a powerup API or lesson format, Effectum lessons should use it for consistency
+- If not, Effectum lessons could be implemented as a guided walkthrough command (`effectum:learn` or `effectum:tutorial`)
+- Lessons should work in both interactive and headless modes (text fallback for CI)
+
+### Phase 3: `effect:next` Integration
+
+Update `effect:next` (the smart router) to recommend `/powerup` when it detects:
+
+- A freshly installed project with no PRDs yet
+- A user who has not run any `effect:dev:*` commands in the current project
+
+```
+💡 Looks like you're just getting started.
+   Run /powerup to learn Claude Code features, or effect:prd:new to write your first spec.
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] `effectum:onboard` completion output includes `/powerup` as a suggested next step
+- [ ] `effectum:setup` completion output includes `/powerup` as a suggested next step
+- [ ] `/effectum` help text mentions `/powerup` under a "Learn" or "Getting Started" section
+- [ ] `effect:next` recommends `/powerup` for fresh projects with no PRDs
+- [ ] No behavioral change for existing users who skip the suggestion
+- [ ] Phase 2 lessons are documented as a follow-up (not blocking v0.20)
+
+---
+
+## Non-Goals
+
+- Not replacing Claude Code's `/powerup` — Effectum references it, does not duplicate it.
+- Not building a full tutorial engine in v0.20 — Phase 2 is a roadmap item.
+- Not gating any Effectum functionality behind completing `/powerup` — it is always optional.
+
+---
+
+## Implementation Notes
+
+- `/powerup` requires Claude Code ≥ v2.1.90
+- Phase 1 is a text-only change to command templates — no new scripts or hooks
+- Phase 2 depends on whether Claude Code exposes a lesson/powerup registration API. Monitor Claude Code changelogs for this.
+- The `/powerup` suggestion should degrade gracefully if the user's Claude Code version does not support it (no error, just skip the suggestion)
+
+---
+
+## Open Questions
+
+1. **Powerup lesson API** — Does Claude Code v2.1.90 expose a way for extensions to register custom powerup lessons? If so, Phase 2 becomes much simpler.
+2. **Version detection** — Should Effectum check the Claude Code version before suggesting `/powerup`? Or just suggest it and let Claude Code handle the "unknown command" case?
+3. **Lesson format** — If Phase 2 proceeds, should lessons be markdown-based (like PRDs) or interactive scripts?


### PR DESCRIPTION
## Summary

Three documentation additions from Claude Code v2.1.89/v2.1.90 intake:

### #022 — defer-permission spec
- `PreToolUse` hooks can return `"defer"` to pause headless sessions
- New `defer-destructive.sh` pattern for human-in-the-loop checkpoints
- Integration with `headless-approver.sh` and `--resume` flow
- Roadmap: v0.17, Priority: P1

### #024 — powerup onboarding spec  
- Claude Code's new `/powerup` command referenced in Effectum `/onboard`
- Effectum-specific lesson roadmap for its own commands
- Roadmap: v0.20, Priority: P1

### Haiku 3 Deprecation Notice
- Added `## Compatibility` section in README.md
- Haiku 3 deprecated April 19, 2026 → migrate to `claude-haiku-4-5`

Built autonomously by Lumi (heartbeat 12:17).