### PR TITLE
docs: PostToolUse format-on-save + Edit/Write 'File content has changed' fix (v2.1.90, intake #023)

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -199,6 +199,8 @@ Blocks the commit/push if any pattern is found.
 **What it does:**
 Runs a formatter after every file edit. In the template this is a placeholder (`echo formatter-not-configured`). Configure it per project by replacing the command with the appropriate formatter (e.g., `prettier --write`, `black`, `gofmt`).
 
+> **v2.1.90+ required for format-on-save hooks:** Before v2.1.90, if a `PostToolUse` format-on-save hook rewrote a file between two consecutive `Edit`/`Write` calls, the second call could fail with `"File content has changed"`. This was a Claude Code bug fixed in v2.1.90. If your project uses a formatter hook and you see this error, upgrade to v2.1.90 or later.
+
 ---
 
 ### PostToolUse — Command audit log

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -69,6 +69,18 @@ Common JSON errors:
 - Add a `ruff.toml` file to configure ruff.
 - Adjust the `FORMATTER_GLOB` to exclude file types that should not be formatted.
 
+### Edit/Write fails with "File content has changed" after formatting
+
+**Symptom**: Claude's second consecutive `Edit` or `Write` on a file fails with an error like `"File content has changed"` when a format-on-save hook is configured.
+
+**Cause**: Before Claude Code v2.1.90, a `PostToolUse` format-on-save hook that rewrote a file immediately after an edit would cause the next `Edit`/`Write` call to see a different file hash than expected, triggering this error.
+
+**Fix**: Upgrade to Claude Code v2.1.90 or later — the race condition is fixed.
+
+**Workaround (older versions)**: Disable the format-on-save hook temporarily, or configure the formatter to only run on explicit save (not on every PostToolUse event).
+
+---
+
 ### File protection blocking legitimate edits
 
 **Symptom**: Claude cannot edit a file that is not actually sensitive.


### PR DESCRIPTION
## Summary

Documents the Claude Code v2.1.90 fix for the format-on-save race condition (intake #023).

**Problem:** Before v2.1.90, a PostToolUse formatter hook rewriting a file could cause the next Edit/Write call to fail with `"File content has changed"`.

**Changes:**
- `docs/hooks.md`: v2.1.90 note added to auto-formatter placeholder section
- `docs/troubleshooting.md`: New troubleshooting entry with symptom, cause, fix, and workaround

**Impact:** docs-only, no code changes, no breaking changes.

Resolves intake #023.