### PR TITLE
chore(intake): Claude Code v2.1.91 — permissions.defaultMode fix, disableSkillShellExecution, Edit-token optimization

### DIFF
--- a/docs/intake-026-v2191.md
+++ b/docs/intake-026-v2191.md
@@ -3,7 +3,20 @@
 _Intake ID: #026_
 _Erfasst: 2026-04-03 von Lumi (Nacht-Heartbeat)_
 _Quelle: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md_
-_CC Version: 2.1.91_
+_CC Version: 2.1.91 (+ v2.1.90 + v2.1.89)_
+
+---
+
+## 🚨 DEPRECATION — Claude Haiku 3 (kritisch für Effectum!)
+
+**Claude Haiku 3 (`claude-3-haiku-20240307`) wird am 19. April 2026 retired.**
+
+Effectum-Relevanz:
+- Effectum README (und PR #17/intake-022) erwähnt Haiku 3 als deprecated → Haiku 4.5 als Nachfolger ✅ (bereits in PR #17 dokumentiert)
+- Heartbeat-Crons die noch `claude-3-haiku-20240307` nutzen → **sofort prüfen!**
+- Effectum `settings.json` Template: welches Modell ist als default hinterlegt?
+
+**Check (03.04.2026):** Kein hardcoded `claude-3-haiku-20240307` in Effectum-Repo oder OpenClaw-Config gefunden. Effectum nutzt nur den abstrakten Alias `haiku` — Claude Code löst das intern auf. **Kein Migrations-Aufwand.** ✅
 
 ---
 

--- a/docs/intake-026-v2191.md
+++ b/docs/intake-026-v2191.md
@@ -1,0 +1,67 @@
+# Feature Intake: Claude Code v2.1.91
+
+_Intake ID: #026_
+_Erfasst: 2026-04-03 von Lumi (Nacht-Heartbeat)_
+_Quelle: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md_
+_CC Version: 2.1.91_
+
+---
+
+## Changelog-Einträge (v2.1.91)
+
+1. **MCP tool result persistence override** — `_meta["anthropic/maxResultSizeChars"]` annotation (up to 500K) — große DB-Schemas können jetzt ungekürzt durchlaufen
+2. **`disableSkillShellExecution`** — neues Setting: deaktiviert Inline-Shell-Execution in Skills, custom Slash-Commands und Plugin-Commands
+3. **Multi-line prompts in deep links** — `claude-cli://open?q=` unterstützt jetzt encoded Newlines (`%0A`)
+4. **Plugin `bin/` executables** — Plugins können jetzt Executables in `bin/` mitliefern, die aus dem Bash-Tool als bare commands aufrufbar sind
+5. **Fix: `--resume` transcript chain breaks** — verlorene Conversation History bei async transcript writes ist gefixt
+6. **Fix: plan mode in remote sessions** — Plan-File-Verlust nach Container-Restart gefixt
+7. **Fix: `permissions.defaultMode: "auto"` JSON schema** — Validierungsfehler in settings.json gefixt (relevant für Effectum!)
+8. **Edit tool shorter anchors** — `old_string` anchors sind jetzt kürzer → weniger Output-Tokens
+9. **`/feedback` now explains unavailability** — UX-Fix
+10. **Improved `/claude-api` skill guidance** — agent design patterns, tool surface decisions, context management, caching strategy
+
+---
+
+## Relevanz-Bewertung für Effectum
+
+### 🔴 Hoch (Effectum betroffene Bereiche)
+
+| # | Feature | Relevanz | Handlungsbedarf |
+|---|---------|----------|-----------------|
+| 7 | `permissions.defaultMode: "auto"` fix | **KRITISCH** | Effectum generiert settings.json — war das Schema falsch validiert? Testen! |
+| 8 | Edit tool shorter `old_string` anchors | **HOCH** | Effectum PRD-Workflow nutzt viele Edit-Calls. Weniger Tokens = schnellere Runs. Ggf. Docs-Update. |
+| 2 | `disableSkillShellExecution` | **MITTEL** | Effectum nutzt Skills — neue Option für sicherere Environments (CI/CD). In Headless-CI-Docs erwähnen. |
+
+### 🟡 Mittel
+
+| # | Feature | Relevanz | Handlungsbedarf |
+|---|---------|----------|-----------------|
+| 4 | Plugin `bin/` executables | **MITTEL** | Falls Effectum Plugin-Support baut (Roadmap item). In Plugin-Spec erwähnen. |
+| 1 | MCP result persistence (500K) | **MITTEL** | Relevant für MCP-Server Integration — DB-Schemas können jetzt ungekürzt durchgehen. |
+
+### ⚪ Niedrig / Kein Handlungsbedarf
+
+- Multi-line deep links (#3) — nicht im Effectum-Scope
+- `--resume` transcript fix (#5) — Bugfix, kein Effectum-Impact
+- Plan-mode remote (#6) — Bugfix, kein Effectum-Impact
+- `/feedback` UX (#9) — kein Effectum-Impact
+- `/claude-api` skill guidance (#10) — tangential (Effectum nutzt claude-api skill intern)
+
+---
+
+## Empfohlene Aktionen
+
+### Sofort (PR #20 empfohlen)
+1. **`permissions.defaultMode: "auto"` testen** — Effectum-generated `settings.json` validieren. Wenn fehlerhaft → Fix in Template.
+2. **Docs: `disableSkillShellExecution`** — Erwähnung in `docs/troubleshooting.md` + `docs/skills.md` für CI-Environments.
+
+### Bald (v0.19 oder v0.20)
+3. **Edit-Token-Optimierung** — Notiz in AUTONOMOUS-WORKFLOW.md: "Edit tool uses shorter anchors since CC v2.1.91 — no Effectum changes needed, performance benefit automatic."
+4. **Plugin `bin/` in Extension-Roadmap** — Feature-Idea für künftigen Plugin-Support.
+
+---
+
+## Status
+- [ ] Jason-Review
+- [ ] PR erstellen (empfohlen: PR #20)
+- [ ] Merge + in CHANGELOG aufnehmen

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -162,6 +162,32 @@ Skills can be published to [clawhub.ai](https://clawhub.ai) using the `clawhub` 
 
 ---
 
+## Security: Disabling Shell Execution in Skills (CI/CD)
+
+By default, skill `SKILL.md` files may include inline shell commands that Claude executes as part of following the skill's instructions. In locked-down CI/CD environments, you may want to prevent this.
+
+Add `disableSkillShellExecution: true` to your `.claude/settings.json` (available since Claude Code v2.1.91):
+
+```json
+{
+  "disableSkillShellExecution": true
+}
+```
+
+**What this affects:**
+- Inline shell execution inside `SKILL.md` instruction sets ✅ blocked
+- Inline shell inside custom slash commands (`.claude/commands/*.md`) ✅ blocked  
+- Inline shell inside plugin command definitions ✅ blocked
+
+**What this does NOT affect:**
+- Regular `Bash(*)` tool calls Claude makes on its own initiative
+- Scripts called via the Bash tool from outside skill definitions
+- MCP server commands
+
+Use this together with [Headless CI Mode](./installation-guide.md) and a restrictive `permissions.allow` list for fully locked-down non-interactive environments.
+
+---
+
 ## Skills vs. Commands vs. Agents
 
 Understanding when to use each extension point:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -187,6 +187,22 @@ If you are on Linux, replace the `osascript` commands with `notify-send` or remo
 
 If it says `"allowEdits"`, Claude will ask before edits. Change to `"bypassPermissions"` for standard autonomy.
 
+### Disabling shell execution in skills (CI/CD environments)
+
+**Symptom**: You want to prevent Claude from running arbitrary shell commands embedded in skill files, custom slash commands, or plugin commands — e.g., in a locked-down CI/CD environment.
+
+**Fix**: Add `disableSkillShellExecution` to your settings (available since Claude Code v2.1.91):
+
+```json
+{
+  "disableSkillShellExecution": true
+}
+```
+
+This disables inline shell execution in skills, custom slash commands, and plugin commands. Note: regular Bash tool calls from Claude itself are unaffected — this only restricts shell commands embedded *inside* skill/command definitions.
+
+Use together with [Headless CI Mode](./installation-guide.md) for fully locked-down non-interactive environments.
+
 ### Claude cannot access MCP servers
 
 **Symptom**: Supabase MCP, Playwright MCP, or other servers are not available.


### PR DESCRIPTION
## Intake #026 — Claude Code v2.1.91

Neue Features aus CC v2.1.91 analysiert und bewertet.

### Top-Findings für Effectum

**🔴 KRITISCH:**
- `permissions.defaultMode: "auto"` JSON schema validation bug gefixt — **Effectum-generated settings.json prüfen!** Wenn unsere Template `"auto"` nutzt, war sie evtl. fehlerhaft.

**🔴 HOCH:**  
- Edit tool nutzt jetzt kürzere `old_string` anchors → weniger Output-Tokens bei PRD-Workflow (automatic benefit, no code change)

**🟡 MITTEL:**
- Neues Setting `disableSkillShellExecution` — für CI-Environments relevant (Headless-CI-Docs)
- Plugin `bin/` executables — Roadmap-Notiz für künftigen Plugin-Support

### Empfohlene Aktionen (PR #20)
1. Effectum `settings.json` Template prüfen — `permissions.defaultMode: "auto"` valide?
2. `disableSkillShellExecution` in `docs/troubleshooting.md` + `docs/skills.md` erwähnen

### Files
- `docs/intake-026-v2191.md` — vollständige Analyse