### PR TITLE
chore(launch): update npm stats — 4,653 March total, 2,625 peak week

### DIFF
--- a/docs/launch/hn-post.md
+++ b/docs/launch/hn-post.md
@@ -42,7 +42,7 @@ The command system got a full UX pass across v0.17 and v0.18. New `/effectum` en
 
 I tried BMAD, GSD, Taskmaster, SpecKit. Each taught me something. Effectum combines what worked: context engineering (GSD), structured specs (SpecKit), autonomous execution with real quality gates, and now progressive disclosure so a first-time user can build something in 10 minutes without reading the docs.
 
-**Traction:** 1,650+ downloads last week on npm — organic, no launch post. That's what finally pushed me to write this.
+**Traction:** 4,600+ downloads in March — organic, no launch post. That's what finally pushed me to write this.
 
 v0.18.3, 539 tests, MIT.
 
@@ -67,7 +67,7 @@ github.com/aslomon/effectum
 > Max iterations configurable (default 30). Stuck Detection stops at 2 repeated errors with diagnosis. Context Budget Monitor stops cleanly at 80% usage. Fails gracefully, never silently.
 
 **"GitHub has 0 stars — is this production-ready?"**  
-> v0.18.3 is stable with 539 passing tests. I've been using it daily on my own projects, and ~3,200 people downloaded it in March without a launch post. Stars are a lagging indicator — hopefully less so after this post.
+> v0.18.3 is stable with 539 passing tests. I've been using it daily on my own projects, and 4,600+ people downloaded it in March without a launch post. Stars are a lagging indicator — hopefully less so after this post.
 
 **"What's the /effect:next command exactly?"**  
 > It reads your current project state: open PRDs, tasks.md status, uncommitted changes, test results. Then recommends exactly one action. First commit? `/effectum:setup`. PRD exists but no tasks? `/prd:task-breakdown`. Tests failing? `/effect:dev:fix`. No ambiguity.
@@ -78,6 +78,6 @@ github.com/aslomon/effectum
 
 - **Best HN posting time:** Tuesday–Thursday, 8–10 AM US Eastern (2–4 PM Berlin)
 - **Weekend posting:** Lower volume but also less competition — Sunday morning ET can work
-- **npm traction:** 1,653 downloads last week, ~3,200 in March total (organic, pre-launch) — mention for credibility
+- **npm traction:** 4,653 downloads in March total, peak week 2,625 (organic, pre-launch) — mention for credibility
 - **v0.18.3 angle:** Namespace clarity + backward compat is the UX story; "539 tests" signals maturity
 - **Competitor context:** AWS Kiro launched (pricing complaints), Windsurf acquired by OpenAI — good moment for "Claude Code native" positioning

--- a/docs/launch/reddit-post.md
+++ b/docs/launch/reddit-post.md
@@ -44,7 +44,7 @@ Curious what your Claude Code workflow looks like — especially around quality 
 ## Post 2: r/SideProject
 
 **Title:**  
-Show r/SideProject: I built an autonomous dev framework for Claude Code (2 months in, ~235 downloads/day)
+Show r/SideProject: I built an autonomous dev framework for Claude Code (2 months in, ~150 downloads/day)
 
 **Body:**
 
@@ -57,7 +57,7 @@ So I spent two months building **Effectum** — an open-source Claude Code frame
 3. **7 stack presets**: Next.js+Supabase, FastAPI, Django+Postgres, Go+Echo, Rust+Actix, Swift/SwiftUI, generic
 4. **Agent Teams**: experimental parallel builds across multiple Claude instances (v0.12.0)
 
-What surprised me: ~235 downloads/day (1,650+ last week) before any community launch. People are apparently searching for this.
+What surprised me: ~150 downloads/day (4,600+ in March) before any community launch. People are apparently searching for this.
 
 `npx @aslomon/effectum` — open source, MIT
 

--- a/docs/launch/twitter-launch-thread.md
+++ b/docs/launch/twitter-launch-thread.md
@@ -71,7 +71,7 @@ One answer. Always.
 ---
 
 **Tweet 6 (traction):**
-1,650+ downloads last week on npm.
+4,600+ downloads in March on npm.
 
 Organic. No launch post.
 


### PR DESCRIPTION
## Launch Posts — Stats Update

Die Download-Zahlen in allen Launch-Posts waren veraltet (1,650/Woche aus März).

### Echte Zahlen (npm API, 2026-03-01 bis 2026-04-02)

| Zeitraum | Downloads |
|----------|-----------|
| März gesamt | **4,653** |
| Peak-Woche W13 (23–29.03) | **2,625** |
| KW14 (30.03–02.04) | 264 |
| April 1+2 | 30 |

### Geänderte Zahlen
- **Vorher:** "1,650+ downloads last week" / "~3,200 in March" / "235 downloads/day"
- **Nachher:** "4,600+ downloads in March" / "4,653 in March total, 2,625 peak week" / "~150 downloads/day"

### Files
- docs/launch/hn-post.md
- docs/launch/reddit-post.md
- docs/launch/twitter-launch-thread.md

**Merge before HN/Reddit post — Mo 06.04 oder Di 07.04, 14-16 Uhr CET**