### PR TITLE
docs(readme): add ai-codex as companion tool in comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ Pull requests for new stacks, presets, and detection rules are especially welcom
 | **SpecKit** | Living specifications | + Autonomous execution + Quality gates + Task registry + Network map |
 | **Taskmaster** | Task breakdown from PRDs | + TDD workflow + Code review + E2E testing + Semantic diff + Onboarding agents |
 | **Kiro (AWS)** | IDE-native spec-driven dev (VS Code fork) | CLI-native. No IDE required. No opaque request pricing. Works with your existing setup. |
+| **ai-codex** | Generates a compact codebase index (saves 50K+ tokens/conversation) | Complementary: run `ai-codex` to generate the index, then use Effectum's `/map-codebase` for the full structured knowledge graph. |
 
 The short version: Effectum doesn't invent new concepts. It combines what already works, removes what doesn't, and packages it so it actually runs.
 


### PR DESCRIPTION
## Summary

Adds `ai-codex` to the comparison table as a companion tool, not a competitor.

**ai-codex:** Generates a compact codebase index for AI assistants — saves 50K+ tokens/conversation.

**Why companion, not competitor:**
- `ai-codex` = lightweight index (flat file summary)
- Effectum `/map-codebase` = structured 7-document knowledge graph (architecture, patterns, data model, etc.)
- Different output, different depth — both useful, composable

**PR #22 context:** Evaluated `ai-codex` on the Effectum repo itself — got 0 output (likely because repo is docs-heavy, not a typical app codebase). Decided: not a fit for our own use, but worth mentioning for users who want a lighter alternative or pre-step.

## Files
- `README.md` — one row added to the comparison table