### PR TITLE
chore(intake): Claude Code v2.1.92 — Stop hook fix, subagent spawning, forceRemoteSettingsRefresh

### DIFF
--- a/docs/agent-teams.md
+++ b/docs/agent-teams.md
@@ -320,3 +320,11 @@ This prints the cost estimate and validates the profile without creating any tea
 **Cause:** The lead's instructions are too vague, or there are ACs with no file ownership match.
 
 **Fix:** Ensure every AC maps to a teammate's file ownership scope. ACs that don't match are assigned to the lead by default — if this happens frequently, adjust file ownership patterns or add a teammate to cover the gap.
+
+### Subagent spawning fails with "Could not determine pane count"
+
+**Symptom:** Teammates fail to spawn permanently mid-session with a tmux-related error.
+
+**Cause:** A pre-CC-v2.1.92 bug where Claude Code lost track of tmux pane counts after windows were killed or renumbered during a long-running session.
+
+**Fix:** Update Claude Code to v2.1.92 or later — the bug is fixed upstream. No Effectum changes needed.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -380,6 +380,8 @@ Return exit code `2` from a `PreToolUse` `command` hook to block the tool call. 
 
 Return `{"ok": false, "reason": "…"}` from a `prompt` or `agent` Stop hook to continue the session. Return `{"ok": true}` to allow stopping.
 
+> **CC v2.1.92 fix:** Prior to v2.1.92, prompt-type Stop hooks that returned `ok:false` could be silently ignored when the small fast model handled the response. This is now fixed. If you observe increased hook-triggered continuations after updating to CC v2.1.92, this is correct behavior — hooks are now reliably respected.
+
 ---
 
 ## Adding a New Hook

--- a/docs/intake-027-v2192.md
+++ b/docs/intake-027-v2192.md
@@ -34,6 +34,7 @@ _CC Version: 2.1.92 (released 2026-04-04)_
 |---|---------|----------|-----------------|
 | 6 | **Stop hook `ok:false` Fix** | **KRITISCH** | Effectum nutzt Stop hooks (type: `prompt`) intensiv — die `completion-check.sh` und `tdd-guard.sh` Hooks. Der Bug bedeutete, dass `ok:false` Rückgaben (= "weiter arbeiten") manchmal **nicht** funktionierten wenn das Fast-Model antwortete. Fix stellt korrekte Semantik wieder her. **Keine Code-Änderung nötig — Effectum-Hooks waren korrekt, der Bug lag in CC.** Aber: Behavioral Change! Hooks die vorher "durchrutschten" blocken jetzt korrekt. Testen. |
 | 7 | **Subagent spawning Fix** | **HOCH** | Agent Teams / SubagentStop-Hooks in Effectum. Permanentes Scheitern bei tmux-Renumbering war ein bekannter Schmerz. Fix hat keine Effectum-Code-Änderung nötig, aber Docs-Update: "CC v2.1.92: Subagent spawning in long tmux sessions ist jetzt stabil." |
+| NEW | **`file_path` jetzt absolut in Pre/PostToolUse-Hooks** | **HOCH (P1)** | Nachmeldung vom Effectum-Impact-Cron (Intake #033). Der v2.1.89-Bug (`file_path` war relativ statt absolut) ist in v2.1.92 gefixt. Das **unblocked PRs #11 + #12** (hooks #017+#018 — permission-denied-handler.sh + compound-cmd-guard.sh). Diese PRs konnten nicht vollständig getestet werden solange file_path relativ war. Jetzt: mergen + auf absolutem file_path testen. |
 
 ### 🟡 Mittel
 
@@ -59,6 +60,7 @@ _CC Version: 2.1.92 (released 2026-04-04)_
 ### Sofort (PR #25 empfohlen)
 1. **Stop hook Behavioral-Change dokumentieren** — `docs/hooks.md` Hinweis: "Since CC v2.1.92: prompt-type Stop hooks with `ok:false` work reliably. If you see increased hook-triggered continuations after updating, this is correct behavior — CC was previously silently ignoring some `ok:false` returns."
 2. **Subagent fix in Agent Teams Docs** — `docs/agent-teams.md` + `docs/teams.md`: Hinweis dass tmux-Session-Renumbering-Bug in CC v2.1.92 gefixt ist.
+3. **`file_path` absolute — PRs #11 + #12 freigeben** — Der file_path-Bug war der Grund warum PRs #11+#12 in der Review-Queue niedrig priorisiert waren. Jetzt können die Hooks korrekt getestet werden. → Intake #033 dokumentiert in `knowledge/projects/effectum-feature-intake.md` (via Impact-Cron, nicht in diesem Intake enthalten).
 
 ### Bald (v0.19 / Docs Pass)
 3. **`forceRemoteSettingsRefresh` in CI-Docs** — `docs/installation-guide.md` Headless-CI-Sektion

--- a/docs/intake-027-v2192.md
+++ b/docs/intake-027-v2192.md
@@ -1,0 +1,72 @@
+# Feature Intake: Claude Code v2.1.92
+
+_Intake ID: #027_
+_Erfasst: 2026-04-04 von Lumi (Nacht-Heartbeat)_
+_Quelle: https://github.com/anthropics/claude-code/releases/tag/v2.1.92_
+_CC Version: 2.1.92 (released 2026-04-04)_
+
+---
+
+## Changelog-Einträge (v2.1.92)
+
+1. **`forceRemoteSettingsRefresh` Policy Setting** — Erzwingt beim Start einen frischen Fetch der Remote Managed Settings; schlägt Startup bei Netzwerk-Fehler fehl (fail-closed)
+2. **Interactive Bedrock Setup Wizard** — Guided AWS Auth + Region + Model-Pinning direkt im Login-Screen, erreichbar via "3rd-party platform"
+3. **`/cost` per-model + cache-hit breakdown** — Subscription-Nutzer sehen jetzt Kosten pro Modell + Cache-Hit-Rate in `/cost`
+4. **`/release-notes` interactive version picker** — Interaktive Versionsauswahl statt nur aktueller Release
+5. **Remote Control Session Names** — Default-Prefix ist jetzt Hostname (`myhost-graceful-unicorn`); überschreibbar mit `--remote-control-session-name-prefix`
+6. **Fix: Stop hooks (prompt type) — `ok:false` semantics restored** — Prompt-type Stop hooks, die `ok:false` zurückgaben, schlugen fälschlicherweise fehl wenn das kleine Fast-Model `ok:false` lieferte. Behoben. `preventContinuation:true` für nicht-Stop prompt-type Hooks ebenfalls restored.
+7. **Fix: Subagent spawning "Could not determine pane count"** — Permanentes Scheitern bei tmux-Window-Kills/Renumbering während langer Sessions
+8. **Fix: Tool input validation failures** — Streaming mit Array/Object-Feldern als JSON-encoded Strings hat Validierung gefehlt
+9. **Fix: API 400 bei extended thinking** — Whitespace-only Text-Block neben realem Content → API 400 Error
+10. **Fix: Feedback Survey Auto-Submissions** — Auto-Pilot Keypresses + digit collisions
+11. **Write tool 60% faster** — Für große Dateien mit Tabs/`&`/`$` (diff computation speed)
+12. **Removed: `/tag` command** — Entfernt (kein Effectum-Bezug)
+13. **Removed: `/vim` command** — Toggle Vim Mode jetzt nur noch via `/config` → Editor mode
+14. **Linux sandbox `apply-seccomp` helper** — Unix-Socket-Blocking wiederhergestellt (npm + native builds)
+
+---
+
+## Relevanz-Bewertung für Effectum
+
+### 🔴 Hoch (direkte Effectum-Auswirkung)
+
+| # | Feature | Relevanz | Handlungsbedarf |
+|---|---------|----------|-----------------|
+| 6 | **Stop hook `ok:false` Fix** | **KRITISCH** | Effectum nutzt Stop hooks (type: `prompt`) intensiv — die `completion-check.sh` und `tdd-guard.sh` Hooks. Der Bug bedeutete, dass `ok:false` Rückgaben (= "weiter arbeiten") manchmal **nicht** funktionierten wenn das Fast-Model antwortete. Fix stellt korrekte Semantik wieder her. **Keine Code-Änderung nötig — Effectum-Hooks waren korrekt, der Bug lag in CC.** Aber: Behavioral Change! Hooks die vorher "durchrutschten" blocken jetzt korrekt. Testen. |
+| 7 | **Subagent spawning Fix** | **HOCH** | Agent Teams / SubagentStop-Hooks in Effectum. Permanentes Scheitern bei tmux-Renumbering war ein bekannter Schmerz. Fix hat keine Effectum-Code-Änderung nötig, aber Docs-Update: "CC v2.1.92: Subagent spawning in long tmux sessions ist jetzt stabil." |
+
+### 🟡 Mittel
+
+| # | Feature | Relevanz | Handlungsbedarf |
+|---|---------|----------|-----------------|
+| 1 | `forceRemoteSettingsRefresh` | **MITTEL** | Effectum Headless CI Mode (PR #10) + Enterprise-Deployments. In `docs/troubleshooting.md` und CI-Docs erwähnen: "Für strikte Managed-Settings-Compliance `forceRemoteSettingsRefresh: true` in der Org-Policy setzen." |
+| 3 | `/cost` per-model breakdown | **MITTEL** | Nützlich für Effectum-Nutzer die Ralph-Loop-Kosten tracken. Erwähnung in `docs/workflow-overview.md` — "use `/cost` to see per-model token breakdown after a Ralph Loop run." |
+| 11 | Write tool 60% faster | **LOW-MITTEL** | Effectum PRD-Workflow generiert viele Write-Calls auf großen Dateien. Automatische Perf-Verbesserung, kein Code nötig. Nur Changelog-Notiz. |
+
+### ⚪ Niedrig / Kein Handlungsbedarf
+
+- Bedrock Setup Wizard (#2) — AWS-Platform spezifisch, kein Effectum-Bezug
+- `/release-notes` Picker (#4) — UI-Feature, kein Effectum-Bezug
+- Remote Control Session Names (#5) — kein Effectum-Bezug
+- `/tag` + `/vim` removed (#12, #13) — kein Effectum-Bezug gefunden (geprüft ✅)
+- Fixes #8, #9, #10 — Bugfixes, kein Effectum-Impact
+- Linux sandbox (#14) — kein direkter Effectum-Impact
+
+---
+
+## Empfohlene Aktionen
+
+### Sofort (PR #25 empfohlen)
+1. **Stop hook Behavioral-Change dokumentieren** — `docs/hooks.md` Hinweis: "Since CC v2.1.92: prompt-type Stop hooks with `ok:false` work reliably. If you see increased hook-triggered continuations after updating, this is correct behavior — CC was previously silently ignoring some `ok:false` returns."
+2. **Subagent fix in Agent Teams Docs** — `docs/agent-teams.md` + `docs/teams.md`: Hinweis dass tmux-Session-Renumbering-Bug in CC v2.1.92 gefixt ist.
+
+### Bald (v0.19 / Docs Pass)
+3. **`forceRemoteSettingsRefresh` in CI-Docs** — `docs/installation-guide.md` Headless-CI-Sektion
+4. **`/cost` Erwähnung in workflow-overview.md** — Als Post-Loop-Debug-Tipp
+
+---
+
+## Status
+- [ ] Jason-Review
+- [ ] PR erstellen (empfohlen: PR #25, `chore/feature-intake-v2.1.92`)
+- [ ] Merge + Intake in knowledge/projects/effectum-feature-intake.md aufnehmen


### PR DESCRIPTION
## CC v2.1.92 Feature Intake (#027)

**Released:** 2026-04-04

### Critical for Effectum

**Stop hook `ok:false` semantics restored (CC v2.1.92 fix)**
Before v2.1.92, prompt-type Stop hooks returning `ok:false` were silently ignored when the small fast model handled the response. Now fixed. Effectum's `completion-check.sh` and `tdd-guard.sh` hooks were correctly written — but they may now trigger more continuations (correct behavior).

**`file_path` now absolute in Pre/PostToolUse hooks (P1)**
The v2.1.89 regression (relative file_path) is fixed in v2.1.92. This **unblocks PRs #11 + #12** (permission-denied-handler.sh + compound-cmd-guard.sh) which couldn't be fully tested with relative paths.

**Subagent spawning fix**
'Could not determine pane count' failure in long tmux sessions is fixed upstream. Added troubleshooting entry to `docs/agent-teams.md`.

### Changes

- `docs/intake-027-v2192.md` — Full intake analysis (updated with file_path finding from Impact Cron)
- `docs/hooks.md` — Behavioral change note for CC v2.1.92 Stop hook fix
- `docs/agent-teams.md` — New troubleshooting entry for subagent spawning

### Merge recommendation
After merging this PR, prioritize merging PRs **#11 + #12** — they are now fully testable.

**Intake file:** `docs/intake-027-v2192.md`