### PR TITLE
feat(loop-worker): refresh preset on current main

### DIFF
--- a/docs/specs/auto-mode-compatibility.md
+++ b/docs/specs/auto-mode-compatibility.md
@@ -1,0 +1,140 @@
+# Spec: Auto Mode Compatibility (Claude Code)
+> Effectum v0.16 candidate | Signal #007 | Created: 2026-03-28
+
+---
+
+## Background
+
+Claude Code introduced **Auto Mode** in March 2026: an AI-powered safety classifier that replaces manual permission prompts. Instead of Claude pausing to ask "allow this bash command?", the classifier automatically approves or denies based on risk assessment.
+
+This changes the interaction model that several Effectum components currently assume.
+
+---
+
+## Current State (v0.15)
+
+### settings.json.tmpl — Permission Config
+```json
+"permissions": {
+  "allow": ["Bash(*)", "Read(*)", "Write(*)", ...],
+  "deny": [...destructive patterns...],
+  "defaultMode": "default"
+}
+```
+
+**Problem:** `defaultMode: "default"` is the pre-Auto-Mode setting. In Auto Mode, this might be overridden or interact unexpectedly with the new classifier.
+
+### Stop Hooks — Type `"prompt"`
+The `settings.json.tmpl` Stop hooks include two `"type": "prompt"` hooks:
+```json
+{"type": "prompt", "prompt": "Evaluate if Claude should stop..."},
+{"type": "prompt", "prompt": "Check if tests were written..."}
+```
+
+**Known issue (documented in MEMORY.md):** Stop hooks of type `"prompt"` can drive Claude Code sessions into loops. One instance of this was fixed in Tangent (commit c62867d) by replacing with `exit 0`.
+
+In Auto Mode, `"prompt"` hooks interact with the safety classifier — behavior is undefined. The classifier may auto-approve or auto-deny hook continuation, causing unpredictable loop or silent-stop behavior.
+
+### bypassPermissions Workflows
+Effectum's standard invocation (from TOOLS.md):
+```
+claude --permission-mode bypassPermissions --print
+```
+`bypassPermissions` bypasses the classifier entirely. This is fine for intentional headless runs, but Effectum-generated CLAUDE.md instructs Claude to "Act autonomously" — users may be confused about which mode applies when.
+
+---
+
+## Risk Assessment
+
+| Component | Risk | Severity |
+|-----------|------|----------|
+| `defaultMode: "default"` in settings.json.tmpl | Auto Mode may override; unclear interaction | Medium |
+| Stop hooks `"type": "prompt"` | Loop risk in Auto Mode (already a known footgun) | High |
+| `bypassPermissions` CLI flag | Works correctly, no change needed | None |
+| CLAUDE.md "Act autonomously" instruction | Fine — reinforces intended behavior | None |
+| Sentinel block (CLAUDE.md) | Passive config block, Auto Mode doesn't touch it | None |
+
+---
+
+## Proposed Changes
+
+### 1. Replace Stop hook `"type": "prompt"` → `exit 0` in settings.json.tmpl (HIGH)
+
+The existing `"prompt"` Stop hooks are already a known footgun (Tangent bug c62867d). Auto Mode makes this worse. Replace the two `"prompt"` Stop hooks with safe `"type": "command"` + `"command": "exit 0"` stubs, or remove them entirely.
+
+**Before:**
+```json
+{
+  "type": "prompt",
+  "prompt": "Evaluate if Claude should stop...",
+  "timeout": 30
+}
+```
+
+**After (option A — remove):** Delete these two prompt-type Stop hooks entirely.
+
+**After (option B — downgrade to command):**
+```json
+{
+  "type": "command",
+  "command": "exit 0",
+  "statusMessage": "Completion check passed"
+}
+```
+
+Recommendation: **Option A** — the stop-quality-check logic is already covered by the `SubagentStop` and `TaskCompleted` hooks. The top-level `Stop` prompt hooks are redundant and dangerous.
+
+### 2. Add `autoMode` field to settings.json.tmpl (MEDIUM)
+
+When Claude Code detects Auto Mode is active, document how Effectum-generated settings interact:
+
+```json
+"permissions": {
+  "allow": [...],
+  "deny": [...],
+  "defaultMode": "auto"  // ← change from "default" to "auto" 
+}
+```
+
+This opts generated projects into Auto Mode by default — removing the manual-approval bottleneck that Effectum workflows already try to minimize via `bypassPermissions`.
+
+**Trade-off:** Some users may want manual review. Consider exposing this in the configurator as an autonomy level:
+- `strict` → `defaultMode: "default"` (manual approvals)
+- `standard` → `defaultMode: "auto"` (classifier-based)  
+- `bypass` → CLI flag `--permission-mode bypassPermissions` (headless/CI)
+
+### 3. Document in `/setup` and README (LOW)
+
+Add a note explaining the three autonomy levels and when to use each. Users coming from pre-Auto-Mode Claude Code may not know this option exists.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `settings.json.tmpl` Stop hooks: no `"type": "prompt"` entries (replaced or removed)
+- [ ] `defaultMode` in `settings.json.tmpl` updated to reflect Auto Mode awareness
+- [ ] Configurator (if prompt-type exists for autonomy level) offers `strict/standard/bypass`
+- [ ] `/setup` docs mention Auto Mode + permission levels
+- [ ] Existing presets tested: generated `settings.json` does not cause loops in a fresh project
+
+---
+
+## Open Questions for Jason
+
+1. **Default autonomy level:** Should new Effectum projects default to `auto` (classifier) or `default` (manual)? Recommendation: `auto` — aligns with Effectum's "trust the workflow" philosophy.
+
+2. **Configurator prompt:** Worth adding an "autonomy level" question to `/setup`? Or hide it as an advanced option?
+
+3. **Remove or stub Stop prompt-hooks?** Option A (remove) is cleaner but loses the "did Claude really finish?" safety net. The `SubagentStop` + `TaskCompleted` hooks cover agent teams. Solo sessions would lose this check.
+
+---
+
+## Roadmap Slot
+
+**v0.16** — can be bundled with Conditional Hooks (`if` field, #001) and Multi-glob (#003). All three are settings/template changes, low implementation risk.
+
+Estimated effort: **0.5 days** (mostly template edits + docs update).
+
+---
+
+*Spec by Lumi (Heartbeat 06:00, 2026-03-28) | Intake Signal #007*

--- a/docs/specs/loop-native-patterns.md
+++ b/docs/specs/loop-native-patterns.md
@@ -1,0 +1,107 @@
+# Spec: /loop Native Patterns in Effectum
+> Effectum v0.16 candidate | Signal #008 | Created: 2026-03-28
+
+---
+
+## Background
+
+Claude Code's `/loop` command turns a session into a **scheduled background worker** — it fires on a cron-like schedule, runs the prompt, and exits. Use cases: PR review on new commits, deployment monitoring, test-run summaries, CI gate checks.
+
+This is directly relevant to Effectum's `/ralph-loop` command (iterative autonomous implementation) and `/orchestrate` (agent team coordination). There's an opportunity to expose `/loop`-native patterns through Effectum's YAML profiles and template system.
+
+---
+
+## Current State (v0.15)
+
+### `/ralph-loop` command
+Currently documented as a manual, interactive "max iterations" loop:
+```
+/ralph-loop [max-iterations=30]
+```
+It's driven by a human starting a session and watching it iterate. No scheduling awareness.
+
+### `/orchestrate` command  
+Spawns parallel subagents for task distribution. Entirely within a single session, no background execution model.
+
+### YAML Profiles (system/presets/)
+8 stack-specific presets. None have a "background worker" or "scheduled task" pattern.
+
+---
+
+## Opportunity
+
+### 1. `loop-first` YAML Profile
+Add a new profile that configures Claude Code for background worker use cases:
+
+```yaml
+id: loop-worker
+label: Background Worker / Scheduled Tasks
+hint: Long-running Claude Code sessions with /loop scheduling
+ecosystem: any
+autonomyLevel: auto
+loopConfig:
+  defaultSchedule: "0 * * * *"  # hourly default
+  maxRuntime: 300  # seconds per loop iteration
+  exitOnError: false
+  transcriptTimestamps: true
+hooks:
+  preLoop:
+    - git fetch --all  # always have latest before each run
+  postLoop:
+    - git status --short  # log what changed
+```
+
+This maps to a generated CLAUDE.md section that explains /loop behavior to the agent.
+
+### 2. `/ralph-loop` YAML Profile Variant
+Add a `ralph-loop-scheduled` profile that wraps `/ralph-loop` in a `/loop` schedule:
+- Run the full PRD implementation cycle once per trigger
+- Useful for overnight builds: "implement this PRD while I sleep, run until done"
+- Stop condition: all acceptance criteria in tasks.md are ✅ DONE
+
+### 3. CLAUDE.md Template Section for /loop Projects
+
+Add an optional `{{LOOP_CONFIG}}` placeholder to `CLAUDE.md.tmpl`:
+
+```markdown
+## Scheduled Execution (when running via /loop)
+
+- Each loop iteration is independent — re-read task state from tasks.md at the start
+- Timestamps are injected into transcript automatically (Claude Code 1.x+)
+- On completion, write a one-line summary to `.claude/loop-summary.log`
+- If all tasks are DONE, exit cleanly — do not invent new work
+- On error, log to `.claude/loop-errors.log` and continue (do not hard-fail)
+```
+
+### 4. Timestamp-Aware Transcript Parsing (Signal #004, #008 combined)
+
+Transcripts now include timestamps when `/loop` fires. Effectum's CHANGELOG agent hook reads transcripts. Worth documenting that timestamp markers can be used for better session reconstruction in post-loop analysis.
+
+---
+
+## Acceptance Criteria
+
+- [ ] New `loop-worker` YAML profile in `system/presets/loop-worker.json`
+- [ ] `CLAUDE.md.tmpl` has `{{LOOP_CONFIG}}` placeholder (optional, empty default)
+- [ ] `/ralph-loop` docs note: "for overnight runs, wrap with `/loop schedule`"
+- [ ] `/orchestrate` docs note: team agents can be triggered via `/loop` for background coordination
+- [ ] README adds a "Scheduled / Background Work" section under Use Cases
+
+---
+
+## Open Questions for Jason
+
+1. Should the `loop-worker` preset be a first-class choice in `/setup`'s "What are you building?" question? Or is it an advanced/opt-in option?
+
+2. `/ralph-loop` + `/loop` combo — is this a use case Jason actually wants to support, or is it too complex for v0.16?
+
+---
+
+## Roadmap Slot
+
+**v0.16** — low-risk (mostly docs + one new preset JSON + template placeholder).  
+Estimated effort: **0.5–1 day**.
+
+---
+
+*Spec by Lumi (Heartbeat 06:00, 2026-03-28) | Intake Signal #008*

--- a/system/presets/loop-worker.json
+++ b/system/presets/loop-worker.json
@@ -1,0 +1,30 @@
+{
+  "id": "loop-worker",
+  "label": "Background Worker / Scheduled Tasks",
+  "hint": "For long-running Claude Code sessions using /loop — PR monitoring, deployment checks, overnight builds",
+  "ecosystem": "any",
+  "kind": "workflow",
+  "framework": null,
+  "database": null,
+  "auth": null,
+  "deploy": null,
+  "orm": null,
+  "packageManager": "npm",
+  "formatter": null,
+  "stack": "loop-worker",
+  "toolsFile": null,
+  "loopConfig": {
+    "defaultSchedule": "0 * * * *",
+    "maxRuntimeSeconds": 300,
+    "exitOnError": false,
+    "transcriptTimestamps": true
+  },
+  "autonomyLevel": "auto",
+  "notes": [
+    "Each /loop iteration is independent — always re-read tasks.md at the start",
+    "On completion, write a one-line summary to .claude/loop-summary.log",
+    "If all tasks are DONE, exit cleanly — do not invent new work",
+    "On error, log to .claude/loop-errors.log and continue (do not hard-fail)",
+    "Combine with /ralph-loop for overnight PRD implementation runs"
+  ]
+}

--- a/system/stacks/loop-worker.md
+++ b/system/stacks/loop-worker.md
@@ -1,0 +1,80 @@
+# Stack Preset: Loop Worker
+
+> Background worker preset for scheduled `/loop` execution, PR monitoring, deployment checks, and overnight autonomous builds.
+
+## TECH_STACK
+
+```
+- Workflow preset for background / scheduled work, not a normal app framework
+- Claude Code `/loop` for recurring execution
+- `tasks.md` as the state source of truth between iterations
+- Transcript timestamps enabled for auditability
+- {{PACKAGE_MANAGER}} available for repo-local scripts when needed
+```
+
+## ARCHITECTURE_PRINCIPLES
+
+```
+- Each loop iteration is independent. Re-read `tasks.md` at the start every time.
+- Prefer small, resumable steps over long speculative runs.
+- Persist state in files and logs, not only in transcript memory.
+- Exit cleanly when all tasks are done. Do not invent filler work.
+- Errors should be logged with enough context to resume on the next iteration.
+```
+
+## PROJECT_STRUCTURE
+
+````
+```
+.claude/
+  loop-summary.log          # one-line summary per completed iteration
+  loop-errors.log           # error log for recoverable failures
+tasks.md                    # queue / state the loop re-reads every run
+```
+````
+
+## QUALITY_GATES
+
+```
+- Every iteration re-reads `tasks.md` before acting
+- Task status changes are persisted immediately
+- Completion is logged to `.claude/loop-summary.log`
+- Recoverable failures are logged to `.claude/loop-errors.log`
+- Loop exits cleanly when no TODO work remains
+```
+
+## FORMATTER
+
+```
+[No stack-specific formatter override]
+```
+
+## FORMATTER_GLOB
+
+```
+md|json
+```
+
+## PACKAGE_MANAGER
+
+```
+{{PACKAGE_MANAGER}}
+```
+
+## STACK_SPECIFIC_GUARDRAILS
+
+```
+- This preset is for scheduled workflows, not normal product scaffolding.
+- Never fake a framework just to satisfy validation.
+- Re-read `tasks.md` at the start of every `/loop` fire.
+- If all tasks are done, exit cleanly instead of generating new work.
+- Log recoverable errors and continue on the next iteration.
+```
+
+## TOOL_SPECIFIC_GUARDRAILS
+
+```
+- Use `/loop` for scheduling, `/ralph-loop` for iterative implementation inside a run.
+- Keep summaries short and append-only.
+- Prefer file-backed state over transcript-only state.
+```

--- a/test/detect.test.js
+++ b/test/detect.test.js
@@ -567,7 +567,15 @@ describe("loadPresets", () => {
       assert.ok(preset.id, `preset missing id: ${JSON.stringify(preset)}`);
       assert.ok(preset.label, `preset ${preset.id} missing label`);
       assert.ok(preset.ecosystem, `preset ${preset.id} missing ecosystem`);
-      assert.ok(preset.framework, `preset ${preset.id} missing framework`);
+      if (preset.kind === "workflow") {
+        assert.equal(
+          preset.framework,
+          null,
+          `workflow preset ${preset.id} must use framework=null`,
+        );
+      } else {
+        assert.ok(preset.framework, `preset ${preset.id} missing framework`);
+      }
       assert.ok(preset.stack, `preset ${preset.id} missing stack`);
     }
   });


### PR DESCRIPTION
## Summary

Refreshes the old PR #6 idea on current `main`, without dragging forward stale branch history.

### What changed
- adds `system/presets/loop-worker.json` as an explicit `kind: "workflow"` preset
- adds `system/stacks/loop-worker.md` so the preset actually injects useful loop guidance via the existing stack-preset path
- keeps the two design/spec docs:
  - `docs/specs/auto-mode-compatibility.md`
  - `docs/specs/loop-native-patterns.md`
- opens preset validation just enough for workflow presets to allow `framework: null`

### Explicit non-goals
- no fake framework just to make CI green
- no general loosening of `framework` for normal presets
- no npm stats report ballast from the old branch
- no dead root-level block file that never gets rendered into `CLAUDE.md`

## Why not merge old #6?

The old branch was stale and mixed the real preset idea with implementation drift. This PR carries the clean current-main rebuild only.

## Validation

- `node --test test/detect.test.js`
